### PR TITLE
Fix #20: add bootstrap runner module for in-process execution

### DIFF
--- a/replaykit/bootstrap.py
+++ b/replaykit/bootstrap.py
@@ -1,0 +1,241 @@
+"""Bootstrap runner for in-process capture of arbitrary Python targets."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import ExitStack
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import runpy
+import sys
+import traceback
+from typing import Sequence
+
+from replaypack.artifact import ArtifactError, SIGNING_KEY_ENV_VAR, write_artifact
+from replaypack.capture import (
+    InterceptionPolicy,
+    capture_run,
+    intercept_httpx,
+    intercept_requests,
+    load_redaction_policy_from_file,
+)
+
+_PYTHON_LIKE_TOKENS = {"python", "python3"}
+_SUPPORTED_INTERCEPTS = ("httpx", "requests")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m replaykit.bootstrap",
+        description=(
+            "Capture a Python script/module in-process and write a ReplayKit artifact."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output path for recorded artifact (.rpk).",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional run identifier. Defaults to a generated bootstrap id.",
+    )
+    parser.add_argument(
+        "--timestamp",
+        default=None,
+        help="Optional fixed run timestamp (ISO-8601).",
+    )
+    parser.add_argument(
+        "--module",
+        default=None,
+        help="Run a module by name (equivalent to python -m <module>).",
+    )
+    parser.add_argument(
+        "--intercept",
+        action="append",
+        choices=_SUPPORTED_INTERCEPTS,
+        default=None,
+        help=(
+            "Repeatable interceptor names. Defaults to both requests and httpx when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--redaction-config",
+        default=None,
+        type=Path,
+        help="Optional path to JSON redaction policy config.",
+    )
+    parser.add_argument(
+        "--sign",
+        action="store_true",
+        help="Attach HMAC signature to output artifact.",
+    )
+    parser.add_argument(
+        "--signing-key",
+        default=os.getenv(SIGNING_KEY_ENV_VAR),
+        help=f"Signing key used when --sign is set (or env {SIGNING_KEY_ENV_VAR}).",
+    )
+    parser.add_argument(
+        "--signing-key-id",
+        default=os.getenv("REPLAYKIT_SIGNING_KEY_ID", "default"),
+        help="Optional signing key identifier stored in signature metadata.",
+    )
+    parser.add_argument(
+        "target",
+        nargs=argparse.REMAINDER,
+        help=(
+            "Target invocation. Use -- to separate bootstrap flags. "
+            "Examples: -- script.py arg1 OR -- -m package.module arg1"
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        spec = _resolve_target_spec(module_flag=args.module, raw_target=args.target)
+    except ValueError as error:
+        parser.error(str(error))
+        return 2
+
+    intercepts = tuple(args.intercept or _SUPPORTED_INTERCEPTS)
+    run_id = args.run_id or _default_run_id()
+
+    redaction_policy = None
+    if args.redaction_config is not None:
+        try:
+            redaction_policy = load_redaction_policy_from_file(args.redaction_config)
+        except FileNotFoundError:
+            print(
+                f"bootstrap failed: redaction config not found: {args.redaction_config}",
+                file=sys.stderr,
+            )
+            return 1
+        except ArtifactError as error:
+            print(f"bootstrap failed: {error}", file=sys.stderr)
+            return 1
+        except ValueError as error:
+            print(f"bootstrap failed: {error}", file=sys.stderr)
+            return 1
+
+    exit_code = 1
+    with capture_run(
+        run_id=run_id,
+        timestamp=args.timestamp,
+        policy=InterceptionPolicy(capture_http_bodies=True),
+        redaction_policy=redaction_policy,
+    ) as capture_context:
+        with ExitStack() as stack:
+            if "requests" in intercepts:
+                stack.enter_context(intercept_requests(context=capture_context))
+            if "httpx" in intercepts:
+                stack.enter_context(intercept_httpx(context=capture_context))
+            exit_code = _execute_target(spec)
+
+        run = capture_context.to_run()
+
+    try:
+        write_artifact(
+            run,
+            args.out,
+            sign=bool(args.sign),
+            signing_key=args.signing_key,
+            signing_key_id=args.signing_key_id,
+            metadata={
+                "bootstrap": True,
+                "target_mode": spec.mode,
+                "target": spec.target,
+                "target_args": list(spec.args),
+                "intercepts": list(intercepts),
+            },
+        )
+    except (ArtifactError, OSError) as error:
+        print(f"bootstrap failed: {error}", file=sys.stderr)
+        return 1
+
+    return exit_code
+
+
+class _TargetSpec:
+    def __init__(self, *, mode: str, target: str, args: tuple[str, ...]) -> None:
+        self.mode = mode
+        self.target = target
+        self.args = args
+
+
+def _resolve_target_spec(
+    *,
+    module_flag: str | None,
+    raw_target: Sequence[str],
+) -> _TargetSpec:
+    target = list(raw_target)
+    if target and target[0] == "--":
+        target = target[1:]
+
+    if target and Path(target[0]).name in _PYTHON_LIKE_TOKENS:
+        target = target[1:]
+
+    if module_flag:
+        module_name = module_flag.strip()
+        if not module_name:
+            raise ValueError("--module must be non-empty")
+        return _TargetSpec(mode="module", target=module_name, args=tuple(target))
+
+    if not target:
+        raise ValueError("missing target invocation; pass script path or -m module")
+
+    if target[0] == "-m":
+        if len(target) < 2 or not target[1].strip():
+            raise ValueError("module mode requires a module name after -m")
+        return _TargetSpec(
+            mode="module",
+            target=target[1],
+            args=tuple(target[2:]),
+        )
+
+    script_path = target[0]
+    return _TargetSpec(mode="script", target=script_path, args=tuple(target[1:]))
+
+
+def _execute_target(spec: _TargetSpec) -> int:
+    previous_argv = list(sys.argv)
+    try:
+        if spec.mode == "module":
+            sys.argv = [spec.target, *spec.args]
+            runpy.run_module(spec.target, run_name="__main__", alter_sys=True)
+        else:
+            sys.argv = [spec.target, *spec.args]
+            runpy.run_path(spec.target, run_name="__main__")
+        return 0
+    except SystemExit as signal:
+        return _system_exit_code(signal)
+    except Exception:  # pragma: no cover - covered by subprocess tests via return code
+        traceback.print_exc()
+        return 1
+    finally:
+        sys.argv = previous_argv
+
+
+def _system_exit_code(signal: SystemExit) -> int:
+    code = signal.code
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    print(str(code), file=sys.stderr)
+    return 1
+
+
+def _default_run_id() -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+    return f"run-bootstrap-{stamp}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,0 +1,122 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from replaypack.artifact import read_artifact
+
+
+def _run_bootstrap(
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "replaykit.bootstrap", *args],
+        capture_output=True,
+        text=True,
+        cwd=Path.cwd(),
+        env=env,
+        check=False,
+    )
+
+
+def test_bootstrap_runs_script_and_writes_artifact(tmp_path: Path) -> None:
+    script_path = tmp_path / "script_target.py"
+    script_path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import threading",
+                "from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer",
+                "import httpx",
+                "import requests",
+                "",
+                "class Handler(BaseHTTPRequestHandler):",
+                "    def do_GET(self):",
+                "        self.send_response(200)",
+                "        self.send_header('Content-Type', 'application/json')",
+                "        self.end_headers()",
+                "        self.wfile.write(json.dumps({'ok': True, 'path': self.path}).encode('utf-8'))",
+                "",
+                "    def log_message(self, fmt, *args):",
+                "        return",
+                "",
+                "server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)",
+                "thread = threading.Thread(target=server.serve_forever, daemon=True)",
+                "thread.start()",
+                "host, port = server.server_address",
+                "base_url = f'http://{host}:{port}'",
+                "try:",
+                "    requests.get(f'{base_url}/requests', timeout=5)",
+                "    httpx.get(f'{base_url}/httpx', timeout=5)",
+                "finally:",
+                "    server.shutdown()",
+                "    server.server_close()",
+                "    thread.join(timeout=2)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "script.rpk"
+
+    result = _run_bootstrap(["--out", str(out_path), "--", str(script_path)])
+
+    assert result.returncode == 0, result.stderr
+    assert out_path.exists()
+    run = read_artifact(out_path)
+    assert len(run.steps) >= 2
+    assert {step.type for step in run.steps}.issuperset({"tool.request", "tool.response"})
+
+
+def test_bootstrap_runs_module_mode(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "samplepkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    output_flag = tmp_path / "module-executed.txt"
+    (pkg_dir / "entry.py").write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "import sys",
+                "",
+                "Path(sys.argv[1]).write_text('ok', encoding='utf-8')",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "module.rpk"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        f"{tmp_path}{os.pathsep}{env.get('PYTHONPATH', '')}".rstrip(os.pathsep)
+    )
+    result = _run_bootstrap(
+        [
+            "--out",
+            str(out_path),
+            "--",
+            "-m",
+            "samplepkg.entry",
+            str(output_flag),
+        ],
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert out_path.exists()
+    assert output_flag.read_text(encoding="utf-8") == "ok"
+
+
+def test_bootstrap_forwards_target_exit_code(tmp_path: Path) -> None:
+    script_path = tmp_path / "exit_7.py"
+    script_path.write_text("raise SystemExit(7)\n", encoding="utf-8")
+    out_path = tmp_path / "exit.rpk"
+
+    result = _run_bootstrap(["--out", str(out_path), "--", str(script_path)])
+
+    assert result.returncode == 7
+    assert out_path.exists()


### PR DESCRIPTION
Implements acceptance criteria for #20.

- Adds python -m replaykit.bootstrap runner.
- Supports script and module execution in-process.
- Forwards target exit codes while writing artifact output.
- Includes subprocess tests for script mode, module mode, and exit forwarding.