### PR TITLE
Fix #19: support non-demo CLI recording wrapper

### DIFF
--- a/examples/apps/minimal_app.py
+++ b/examples/apps/minimal_app.py
@@ -1,0 +1,52 @@
+"""Minimal local-only app used for ReplayKit record wrapper smoke tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import requests
+
+from replaypack.capture import tool
+
+
+@tool(name="example.echo")
+def example_tool(value: str) -> dict[str, str]:
+    return {"echo": value}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "ReplayKitExample/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        payload = {"ok": True, "path": self.path}
+        self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    host, port = server.server_address
+    base_url = f"http://{host}:{port}"
+    try:
+        requests.get(f"{base_url}/requests", timeout=5)
+        httpx.get(f"{base_url}/httpx", timeout=5)
+        example_tool("hello")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_record_demo.py
+++ b/tests/test_cli_record_demo.py
@@ -21,12 +21,12 @@ def test_record_demo_writes_artifact(tmp_path: Path) -> None:
     assert len(run.steps) == 6
 
 
-def test_record_without_demo_flag_fails() -> None:
+def test_record_without_demo_flag_requires_target() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["record", "--no-demo"])
 
     assert result.exit_code == 2
-    assert "only --demo is supported in M2" in result.output
+    assert "--no-demo requires a target command" in result.output
 
 
 def test_record_with_redaction_config_masks_custom_field(tmp_path: Path) -> None:

--- a/tests/test_cli_record_wrapper.py
+++ b/tests/test_cli_record_wrapper.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import httpx
+import requests
+from typer.testing import CliRunner
+
+from replaypack.artifact import read_artifact
+from replaypack.cli.app import app
+
+
+def test_record_wrapper_executes_target_app_and_captures_steps(tmp_path: Path) -> None:
+    out_path = tmp_path / "wrapped.rpk"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "record",
+            "--out",
+            str(out_path),
+            "--",
+            "python",
+            "examples/apps/minimal_app.py",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out_path.exists()
+
+    run = read_artifact(out_path)
+    assert len(run.steps) >= 4
+    boundaries = {step.metadata.get("boundary") for step in run.steps}
+    assert "http" in boundaries
+
+
+def test_record_wrapper_restores_http_patches_after_run(tmp_path: Path) -> None:
+    out_path = tmp_path / "wrapped-cleanup.rpk"
+    original_requests = requests.sessions.Session.request
+    original_httpx_client = httpx.Client.request
+    original_httpx_async = httpx.AsyncClient.request
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "record",
+            "--out",
+            str(out_path),
+            "--",
+            "python",
+            "examples/apps/minimal_app.py",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert requests.sessions.Session.request is original_requests
+    assert httpx.Client.request is original_httpx_client
+    assert httpx.AsyncClient.request is original_httpx_async


### PR DESCRIPTION
Implements acceptance criteria for #19.

- Enables replaykit record -- ... target execution path.
- Runs target in-process with scoped requests/httpx interception.
- Writes artifacts from captured target runs and restores patches after completion.
- Adds local-only example app and CLI wrapper tests.