### PR TITLE
Fix #24: release readiness docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows Keep a Changelog and Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+
+- Placeholder for upcoming changes.
+
+## [0.1.0] - 2026-02-22
+
+### Added
+
+- Deterministic artifact format with schema validation and migration support.
+- Capture boundaries for model/tool/http events with redaction.
+- Offline replay (stub + hybrid) and first-divergence diffing.
+- CLI commands for record/replay/diff/assert/bundle/verify/snapshot/benchmark/migrate/ui.
+- Local diff UI and CI parity/assert integration.
+
+### Security
+
+- Redaction defaults for common secret-bearing fields and signature verification workflow.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ Public API compatibility policy and semver guarantees:
 
 - `docs/PUBLIC_API.md`
 
+Release and upgrade policy:
+
+- `CHANGELOG.md`
+- `docs/RELEASES.md`
+
 ## License
 
 MIT

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,55 @@
+# Release Process
+
+This document defines the release/tag workflow for ReplayKit.
+
+## Version Source of Truth
+
+- Runtime/library version is stored in `replaykit/__init__.py` as `__version__`.
+- Release tags must match this value: `v<version>` (for example `v0.1.0`).
+
+## Upgrade Policy
+
+- Semantic versioning is used for public API behavior:
+  - Patch: bug fixes and internal changes with no public API break.
+  - Minor: additive public API changes.
+  - Major: breaking public API changes.
+- Public API compatibility contract is documented in `docs/PUBLIC_API.md`.
+- Artifact schema migrations must remain documented in `docs/ARTIFACT_MIGRATION.md`.
+
+## Cut a Release Tag
+
+1. Ensure `main` is green in CI.
+2. Update:
+   - `replaykit/__init__.py` (`__version__`)
+   - `CHANGELOG.md` (`[Unreleased]` -> new version/date section)
+3. Commit and push:
+
+```bash
+git checkout main
+git pull --rebase
+git add replaykit/__init__.py CHANGELOG.md
+git commit -m "chore(release): vX.Y.Z"
+git push origin main
+```
+
+4. Create annotated tag and push:
+
+```bash
+git tag -a vX.Y.Z -m "ReplayKit vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+5. Create GitHub release notes from `CHANGELOG.md`:
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file CHANGELOG.md
+```
+
+## Verify Post-Release
+
+```bash
+python3 - <<'PY'
+import replaykit
+print(replaykit.__version__)
+PY
+```

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import re
+
+import replaykit
+
+
+def test_release_artifacts_exist_and_version_is_semver_like() -> None:
+    assert Path("CHANGELOG.md").exists()
+    assert Path("docs/RELEASES.md").exists()
+    assert re.fullmatch(r"\d+\.\d+\.\d+", replaykit.__version__) is not None
+
+
+def test_release_docs_reference_tag_and_upgrade_policy() -> None:
+    text = Path("docs/RELEASES.md").read_text(encoding="utf-8").lower()
+    assert "semantic versioning" in text
+    assert "git tag -a vx.y.z" in text
+    assert "docs/public_api.md" in text


### PR DESCRIPTION
Implements acceptance criteria for #24.

- Adds CHANGELOG.md.
- Documents release/tag process and upgrade policy in docs/RELEASES.md.
- Confirms replaykit.__version__ presence and semver-style format via tests.
- Links release policy from README.