### PR TITLE
Fix #70: Add CI golden-path guards for target and fake-provider capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
         run: |
           python -m pytest -q tests/test_e2e_record_replay_assert.py
 
+      - name: Golden Path Target Record CLI Guard
+        run: |
+          python -m pytest -q tests/test_cli_record_target.py
+
+      - name: Golden Path Fake-Provider LLM Capture Guard
+        run: |
+          python -c "from pathlib import Path; Path('runs/golden').mkdir(parents=True, exist_ok=True)"
+          python -m replaypack live-demo --provider fake --stream --out runs/golden/fake-provider-llm.rpk --json > runs/golden/fake-provider-llm-summary.json
+          python -m replaypack replay runs/golden/fake-provider-llm.rpk --out runs/golden/fake-provider-llm-replay-a.rpk --seed 9 --fixed-clock 2026-02-22T00:00:00Z
+          python -m replaypack replay runs/golden/fake-provider-llm.rpk --out runs/golden/fake-provider-llm-replay-b.rpk --seed 9 --fixed-clock 2026-02-22T00:00:00Z
+          python -m replaypack assert runs/golden/fake-provider-llm-replay-a.rpk --candidate runs/golden/fake-provider-llm-replay-b.rpk --json > runs/golden/fake-provider-llm-assert.json
+          echo "Fake-provider LLM capture guard completed (runs/golden/fake-provider-llm*)."
+
       - name: Replay Assertion
         run: |
           python -c "from pathlib import Path; Path('runs').mkdir(parents=True, exist_ok=True)"


### PR DESCRIPTION
Closes #70.\n\nTests run:\n- python3 -m pytest -q