### PR TITLE
Fix #71: Add release notes flow for provider capture and target recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format follows Keep a Changelog and Semantic Versioning.
   - README install section now documents both `pip install -e .` and
     `python3 -m pip install -e \".[dev]\"`.
   - Release process docs continue to use GitHub release notes from `CHANGELOG.md`.
+- Provider-capture + target-recording release notes template added:
+  - `docs/release-notes-provider-capture-target-recording.md`.
+  - `docs/RELEASES.md` now includes explicit command examples for publishing notes.
 
 ## [0.1.0] - 2026-02-22
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -45,6 +45,23 @@ git push origin vX.Y.Z
 gh release create vX.Y.Z --title "vX.Y.Z" --notes-file CHANGELOG.md
 ```
 
+## Provider Capture + Target Recording Release Notes
+
+Use the curated release notes file when shipping provider-capture and target-record
+milestones:
+
+```bash
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes-file docs/release-notes-provider-capture-target-recording.md
+```
+
+Recommended flow:
+
+1. Update `docs/release-notes-provider-capture-target-recording.md`.
+2. Cut and push tag (`vX.Y.Z`).
+3. Publish release notes via `gh release create`.
+
 ## Verify Post-Release
 
 ```bash

--- a/docs/release-notes-provider-capture-target-recording.md
+++ b/docs/release-notes-provider-capture-target-recording.md
@@ -1,0 +1,30 @@
+# ReplayKit Release Notes: Provider Capture + Target Recording
+
+## Highlights
+
+- Added first-class target command recording flow:
+  - `replaykit record --out runs/app.rpk -- python examples/apps/minimal_app.py`
+- Added provider-shaped capture workflow for local deterministic model debugging.
+- Expanded CI golden-path checks for record/replay/assert/diff invariants.
+
+## Why This Release
+
+This release hardens ReplayKit's production debugging path around two core use
+cases:
+
+1. Record real target app behavior without modifying application code.
+2. Capture provider request/response shape in deterministic local workflows.
+
+## Verification Commands
+
+```bash
+python3 -m pytest -q
+replaykit record --out runs/release-target.rpk -- python examples/apps/minimal_app.py
+replaykit replay runs/release-target.rpk --out runs/release-target-replay.rpk
+replaykit assert runs/release-target-replay.rpk --candidate runs/release-target-replay.rpk --json
+```
+
+## Notes
+
+- Replay remains offline deterministic.
+- No provider secrets should be committed to artifacts or repository files.

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -15,6 +15,7 @@ def test_release_docs_reference_tag_and_upgrade_policy() -> None:
     assert "semantic versioning" in text
     assert "git tag -a vx.y.z" in text
     assert "docs/public_api.md" in text
+    assert "release-notes-provider-capture-target-recording.md" in text
 
 
 def test_readme_includes_ci_badge_and_stability_statement() -> None:
@@ -25,3 +26,12 @@ def test_readme_includes_ci_badge_and_stability_statement() -> None:
     assert "platform guarantees" in text
     assert "semantic versioning policy" in text
     assert "backward compatibility guarantees" in text
+
+
+def test_provider_capture_release_notes_template_exists() -> None:
+    text = Path("docs/release-notes-provider-capture-target-recording.md").read_text(
+        encoding="utf-8"
+    ).lower()
+    assert "provider capture" in text
+    assert "target command recording" in text
+    assert "replay remains offline deterministic" in text


### PR DESCRIPTION
Closes #71.\n\nTests run:\n- python3 -m pytest -q