### PR TITLE
GAP-03: Build listener daemon CLI

### DIFF
--- a/replaypack/listener_daemon.py
+++ b/replaypack/listener_daemon.py
@@ -1,0 +1,149 @@
+"""Passive listener daemon process for ReplayKit lifecycle commands."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import urlsplit
+
+from replaypack.listener_state import remove_listener_state, write_listener_state
+
+
+class _ReplayListenerServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
+        *,
+        session_id: str,
+        state_file: Path,
+    ) -> None:
+        super().__init__(server_address, request_handler_class)
+        self.session_id = session_id
+        self.state_file = state_file
+
+
+class _ListenerHandler(BaseHTTPRequestHandler):
+    server: _ReplayListenerServer
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path == "/health":
+            self._write_json(
+                200,
+                {
+                    "status": "ok",
+                    "session_id": self.server.session_id,
+                    "pid": os.getpid(),
+                },
+            )
+            return
+        self._write_json(404, {"status": "error", "message": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path == "/shutdown":
+            self._write_json(
+                200,
+                {"status": "ok", "message": "listener shutting down"},
+            )
+
+            def _shutdown() -> None:
+                self.server.shutdown()
+
+            threading.Thread(target=_shutdown, daemon=True).start()
+            return
+        self._write_json(404, {"status": "error", "message": "not found"})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def _write_json(self, status_code: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, ensure_ascii=True, sort_keys=True).encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m replaypack.listener_daemon",
+        description="ReplayKit passive listener daemon process.",
+    )
+    parser.add_argument("--state-file", required=True, type=Path)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=0, type=int)
+    parser.add_argument("--session-id", required=True)
+    return parser
+
+
+def _runtime_payload(*, session_id: str, host: str, port: int) -> dict[str, Any]:
+    return {
+        "status": "running",
+        "listener_session_id": session_id,
+        "pid": os.getpid(),
+        "host": host,
+        "port": port,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "process": {
+            "pid": os.getpid(),
+            "executable": sys.executable,
+            "command": list(sys.argv),
+            "cwd": str(Path.cwd()),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    server: _ReplayListenerServer | None = None
+
+    try:
+        server = _ReplayListenerServer(
+            (args.host, args.port),
+            _ListenerHandler,
+            session_id=args.session_id,
+            state_file=args.state_file,
+        )
+    except OSError as error:
+        print(f"listener daemon failed: {error}", file=sys.stderr)
+        return 1
+
+    host, port = server.server_address[0], int(server.server_address[1])
+    write_listener_state(
+        args.state_file,
+        _runtime_payload(
+            session_id=args.session_id,
+            host=host,
+            port=port,
+        ),
+    )
+
+    def _handle_signal(_signum: int, _frame: Any) -> None:
+        if server is not None:
+            server.shutdown()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    try:
+        server.serve_forever(poll_interval=0.2)
+    finally:
+        remove_listener_state(args.state_file)
+        server.server_close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/replaypack/listener_state.py
+++ b/replaypack/listener_state.py
@@ -1,0 +1,61 @@
+"""Persistent state helpers for passive listener daemon lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def default_listener_state_path() -> Path:
+    return Path("runs/listener/state.json")
+
+
+def load_listener_state(path: str | Path) -> dict[str, Any] | None:
+    target = Path(path)
+    if not target.exists():
+        return None
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return raw
+
+
+def write_listener_state(path: str | Path, payload: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def remove_listener_state(path: str | Path) -> None:
+    target = Path(path)
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        return
+
+
+def is_pid_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if hasattr(os, "waitpid"):
+        try:
+            waited_pid, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            waited_pid = 0
+        if waited_pid == pid:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/tests/test_cli_listen.py
+++ b/tests/test_cli_listen.py
@@ -1,0 +1,158 @@
+import json
+from pathlib import Path
+import socket
+
+from typer.testing import CliRunner
+
+from replaypack.cli.app import app
+
+
+def test_cli_listen_start_status_stop_cycle_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+
+    start = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert start.exit_code == 0, start.output
+    started = json.loads(start.stdout.strip())
+    assert started["status"] == "ok"
+    assert started["listener_session_id"]
+    assert started["pid"] > 0
+    assert started["port"] > 0
+
+    status_running = runner.invoke(
+        app,
+        [
+            "listen",
+            "status",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert status_running.exit_code == 0, status_running.output
+    running_payload = json.loads(status_running.stdout.strip())
+    assert running_payload["running"] is True
+    assert running_payload["listener_session_id"] == started["listener_session_id"]
+    assert running_payload["pid"] == started["pid"]
+    assert running_payload["healthy"] is True
+
+    stop = runner.invoke(
+        app,
+        [
+            "listen",
+            "stop",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert stop.exit_code == 0, stop.output
+    stopped = json.loads(stop.stdout.strip())
+    assert stopped["status"] == "ok"
+    assert "stopped" in stopped["message"]
+
+    status_stopped = runner.invoke(
+        app,
+        [
+            "listen",
+            "status",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert status_stopped.exit_code == 0, status_stopped.output
+    stopped_payload = json.loads(status_stopped.stdout.strip())
+    assert stopped_payload["running"] is False
+
+
+def test_cli_listen_status_cleans_stale_pid_state(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "listener_session_id": "listener-stale-001",
+                "pid": 999999,
+                "host": "127.0.0.1",
+                "port": 9000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "listen",
+            "status",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout.strip())
+    assert payload["running"] is False
+    assert payload["stale_cleanup"] is True
+    assert not state_file.exists()
+
+
+def test_cli_listen_start_rejects_port_conflict(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "listen",
+                "start",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+    finally:
+        sock.close()
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout.strip())
+    assert payload["status"] == "error"
+    assert "unavailable" in payload["message"]
+
+
+def test_cli_listen_stop_when_already_stopped_is_idempotent(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    result = runner.invoke(
+        app,
+        [
+            "listen",
+            "stop",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout.strip())
+    assert payload["status"] == "ok"
+    assert "already stopped" in payload["message"]


### PR DESCRIPTION
## Summary
- Add passive listener lifecycle command group: `listen start`, `listen stop`, `listen status`.
- Implement daemon process module with health and shutdown endpoints.
- Add persistent listener state helpers with stale PID cleanup.
- Add lifecycle tests covering start/status/stop, stale state cleanup, idempotent stop, and port conflicts.

## Acceptance Criteria
- [x] `listen start|stop|status` implemented.
- [x] PID/session tracking persisted in state file.
- [x] Port conflict errors are explicit.
- [x] Stale PID/session cleanup works.
- [x] Repeated start/stop cycles are stable.

## Test Evidence
- `python3 -m pytest -q tests/test_cli_listen.py`
- Result: `4 passed`
- `python3 -m pytest -q`
- Result: `238 passed`

## Risks
- Daemon transport is currently lifecycle-only; provider capture routes are added in GAP-04.

## Rollback
- Revert commit `47a4d05`.
