### PR TITLE
GAP-06: Add agent passive capture adapters

### DIFF
--- a/replaypack/listener_agent_gateway.py
+++ b/replaypack/listener_agent_gateway.py
@@ -1,0 +1,103 @@
+"""Passive coding-agent event normalization for listener mode."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_SUPPORTED_AGENTS = {"codex", "claude-code"}
+
+
+def detect_agent(path: str) -> str | None:
+    normalized = path.strip().rstrip("/")
+    if normalized == "/agent/codex/events":
+        return "codex"
+    if normalized == "/agent/claude-code/events":
+        return "claude-code"
+    return None
+
+
+def normalize_agent_events(
+    *,
+    agent: str,
+    payload: Any,
+) -> tuple[list[dict[str, Any]], int]:
+    if agent not in _SUPPORTED_AGENTS:
+        raise ValueError(f"unsupported agent: {agent}")
+
+    raw_events: list[Any]
+    if isinstance(payload, dict) and isinstance(payload.get("events"), list):
+        raw_events = list(payload["events"])
+    elif isinstance(payload, list):
+        raw_events = list(payload)
+    elif isinstance(payload, dict):
+        raw_events = [payload]
+    else:
+        return [], 1
+
+    normalized: list[dict[str, Any]] = []
+    dropped = 0
+    for raw_event in raw_events:
+        if not isinstance(raw_event, dict):
+            dropped += 1
+            continue
+
+        event_type = str(raw_event.get("type", "")).strip().lower()
+        if not event_type:
+            dropped += 1
+            continue
+
+        metadata = {"agent": agent, "event_type": event_type}
+        extra_metadata = raw_event.get("metadata")
+        if isinstance(extra_metadata, dict):
+            metadata.update(extra_metadata)
+
+        request_id = raw_event.get("request_id")
+        normalized_event: dict[str, Any]
+        if event_type == "model.request":
+            normalized_event = {
+                "step_type": "model.request",
+                "input": raw_event.get("input", {}),
+                "output": {"status": "captured"},
+                "metadata": metadata,
+                "request_id": request_id,
+            }
+        elif event_type == "model.response":
+            normalized_event = {
+                "step_type": "model.response",
+                "input": {"request_id": request_id},
+                "output": raw_event.get("output", raw_event),
+                "metadata": metadata,
+                "request_id": request_id,
+            }
+        elif event_type == "tool.request":
+            normalized_event = {
+                "step_type": "tool.request",
+                "input": raw_event.get("input", {}),
+                "output": {"status": "captured"},
+                "metadata": metadata,
+                "request_id": request_id,
+            }
+        elif event_type == "tool.response":
+            normalized_event = {
+                "step_type": "tool.response",
+                "input": {"tool": raw_event.get("tool")},
+                "output": {"agent": agent, "event": raw_event.get("output", raw_event)},
+                "metadata": metadata,
+                "request_id": request_id,
+            }
+        elif event_type == "error.event":
+            normalized_event = {
+                "step_type": "error.event",
+                "input": {"agent": agent},
+                "output": raw_event.get("output", raw_event),
+                "metadata": metadata,
+                "request_id": request_id,
+            }
+        else:
+            dropped += 1
+            continue
+
+        normalized.append(normalized_event)
+
+    return normalized, dropped

--- a/tests/test_listener_agent_gateway.py
+++ b/tests/test_listener_agent_gateway.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+import requests
+from typer.testing import CliRunner
+
+from replaypack.artifact import read_artifact
+from replaypack.cli.app import app
+from replaypack.listener_agent_gateway import detect_agent, normalize_agent_events
+
+
+def test_listener_agent_gateway_detect_and_normalize() -> None:
+    assert detect_agent("/agent/codex/events") == "codex"
+    assert detect_agent("/agent/claude-code/events") == "claude-code"
+    assert detect_agent("/agent/unknown/events") is None
+
+    events, dropped = normalize_agent_events(
+        agent="codex",
+        payload={
+            "events": [
+                {"type": "model.request", "input": {"model": "gpt-4o-mini"}},
+                {
+                    "type": "model.response",
+                    "request_id": "req-1",
+                    "output": {"content": "Hello"},
+                },
+            ]
+        },
+    )
+    assert dropped == 0
+    assert [event["step_type"] for event in events] == [
+        "model.request",
+        "model.response",
+    ]
+
+
+def test_listener_agent_gateway_captures_codex_and_claude_events(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    out_path = tmp_path / "listener-agent-capture.rpk"
+
+    start_result = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--out",
+            str(out_path),
+            "--json",
+        ],
+    )
+    assert start_result.exit_code == 0, start_result.output
+    started = json.loads(start_result.stdout.strip())
+    base_url = f"http://{started['host']}:{started['port']}"
+
+    try:
+        codex = requests.post(
+            f"{base_url}/agent/codex/events",
+            json={
+                "events": [
+                    {
+                        "type": "model.request",
+                        "input": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+                        "metadata": {"provider": "openai"},
+                    },
+                    {
+                        "type": "model.response",
+                        "request_id": "req-codex-1",
+                        "output": {"content": "hello"},
+                        "metadata": {"provider": "openai"},
+                    },
+                ]
+            },
+            timeout=2.0,
+        )
+        assert codex.status_code == 202
+        codex_payload = codex.json()
+        assert codex_payload["captured"] == 2
+        assert codex_payload["dropped"] == 0
+
+        claude = requests.post(
+            f"{base_url}/agent/claude-code/events",
+            json=[
+                {"type": "tool.request", "input": {"tool": "read_file", "args": ["README.md"]}},
+                {"type": "tool.response", "tool": "read_file", "output": {"ok": True}},
+            ],
+            timeout=2.0,
+        )
+        assert claude.status_code == 202
+        claude_payload = claude.json()
+        assert claude_payload["captured"] == 2
+        assert claude_payload["dropped"] == 0
+
+        malformed = requests.post(
+            f"{base_url}/agent/codex/events",
+            data="not-json",
+            headers={"Content-Type": "application/json"},
+            timeout=2.0,
+        )
+        assert malformed.status_code == 202
+        malformed_payload = malformed.json()
+        assert malformed_payload["captured"] == 0
+        assert malformed_payload["dropped"] >= 1
+    finally:
+        stop_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop_result.exit_code == 0, stop_result.output
+
+    run = read_artifact(out_path)
+    step_types = [step.type for step in run.steps]
+    assert "model.request" in step_types
+    assert "model.response" in step_types
+    assert "tool.request" in step_types
+    assert "tool.response" in step_types
+    assert "error.event" in step_types
+    agents = {step.metadata.get("agent") for step in run.steps if step.metadata.get("agent")}
+    assert {"codex", "claude-code"} <= agents


### PR DESCRIPTION
## Summary
- Add passive agent gateway module for Codex and Claude Code event paths.
- Extend listener daemon with `/agent/codex/events` and `/agent/claude-code/events` endpoints.
- Normalize agent events into canonical replay step types.
- Add graceful malformed-frame handling with non-blocking `202` responses and diagnostic `error.event` capture.

## Acceptance Criteria
- [x] Codex and Claude Code passive endpoints implemented.
- [x] Event ordering preserved in captured artifact sequence.
- [x] Session/event correlation preserved with request IDs (or deterministic fallback IDs).
- [x] Malformed/unsupported frames degrade gracefully without hard failure.

## Test Evidence
- `python3 -m pytest -q tests/test_cli_listen.py tests/test_listener_gateway.py tests/test_listener_agent_gateway.py`
- Result: `9 passed`
- `python3 -m pytest -q`
- Result: `243 passed`

## Risks
- Agent event schema remains adapter-driven; additional real-world event variants may require mapper expansion.

## Rollback
- Revert commit `a43baed`.
