### PR TITLE
GAP-08: Add failure isolation for passive listener

### DIFF
--- a/replaypack/listener_gateway.py
+++ b/replaypack/listener_gateway.py
@@ -125,6 +125,36 @@ def build_provider_response(
     return 200, response, normalized
 
 
+def build_best_effort_fallback_response(
+    *,
+    provider: str,
+    sequence: int,
+) -> tuple[int, dict[str, Any]]:
+    text = "ReplayKit capture degraded fallback response"
+    if provider == "openai":
+        body = {
+            "id": f"chatcmpl-fallback-{sequence:06d}",
+            "object": "chat.completion",
+            "choices": [{"message": {"role": "assistant", "content": text}}],
+            "_replaykit": {"capture_status": "degraded"},
+        }
+    elif provider == "anthropic":
+        body = {
+            "id": f"msg-fallback-{sequence:06d}",
+            "type": "message",
+            "content": [{"type": "text", "text": text}],
+            "_replaykit": {"capture_status": "degraded"},
+        }
+    else:
+        body = {
+            "candidates": [
+                {"content": {"role": "model", "parts": [{"text": text}]}}
+            ],
+            "_replaykit": {"capture_status": "degraded"},
+        }
+    return 200, body
+
+
 def normalize_provider_response(
     *,
     provider: str,

--- a/tests/test_listener_failure_isolation.py
+++ b/tests/test_listener_failure_isolation.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+
+import requests
+from typer.testing import CliRunner
+
+from replaypack.artifact import read_artifact
+from replaypack.cli.app import app
+
+
+def test_listener_provider_capture_failure_serves_degraded_fallback(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    out_path = tmp_path / "listener-failure.rpk"
+
+    start_result = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--out",
+            str(out_path),
+            "--json",
+        ],
+    )
+    assert start_result.exit_code == 0, start_result.output
+    started = json.loads(start_result.stdout.strip())
+    base_url = f"http://{started['host']}:{started['port']}"
+
+    try:
+        response = requests.post(
+            f"{base_url}/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+            headers={"x-replaykit-capture-fail": "1"},
+            timeout=2.0,
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["_replaykit"]["capture_status"] == "degraded"
+
+        status_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "status",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert status_result.exit_code == 0, status_result.output
+        status_payload = json.loads(status_result.stdout.strip())
+        assert status_payload["running"] is True
+        metrics = status_payload["health"]["metrics"]
+        assert metrics["capture_errors"] >= 1
+        assert metrics["degraded_responses"] >= 1
+    finally:
+        stop_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop_result.exit_code == 0, stop_result.output
+
+    run = read_artifact(out_path)
+    error_steps = [
+        step
+        for step in run.steps
+        if step.type == "error.event" and step.metadata.get("category") == "capture_failure"
+    ]
+    assert error_steps
+    assert "degraded fallback response" in error_steps[-1].output["message"]
+
+
+def test_listener_agent_malformed_frames_increment_dropped_metrics(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    out_path = tmp_path / "listener-failure-agent.rpk"
+
+    start_result = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--out",
+            str(out_path),
+            "--json",
+        ],
+    )
+    assert start_result.exit_code == 0, start_result.output
+    started = json.loads(start_result.stdout.strip())
+    base_url = f"http://{started['host']}:{started['port']}"
+
+    try:
+        malformed = requests.post(
+            f"{base_url}/agent/codex/events",
+            data="not-json",
+            headers={"Content-Type": "application/json"},
+            timeout=2.0,
+        )
+        assert malformed.status_code == 202
+        malformed_payload = malformed.json()
+        assert malformed_payload["dropped"] >= 1
+        assert malformed_payload["metrics"]["dropped_events"] >= 1
+
+        status_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "status",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert status_result.exit_code == 0, status_result.output
+        status_payload = json.loads(status_result.stdout.strip())
+        assert status_payload["health"]["metrics"]["dropped_events"] >= 1
+    finally:
+        stop_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop_result.exit_code == 0, stop_result.output


### PR DESCRIPTION
## Summary
- Add best-effort failure isolation when capture internals fail.
- On capture failure, provider endpoints return degraded fallback success payloads instead of hard failures.
- Add listener health metrics (`capture_errors`, `dropped_events`, `degraded_responses`) for diagnosis.
- Record internal capture-failure diagnostics as `error.event` steps for postmortem diff/replay workflows.

## Acceptance Criteria
- [x] Capture-path failures no longer hard-break target caller flow by default.
- [x] Degraded behavior is observable via health/status metrics.
- [x] Failure diagnostics are persisted as structured events.
- [x] Malformed agent frame drops are visible and counted.

## Test Evidence
- `python3 -m pytest -q tests/test_listener_failure_isolation.py tests/test_cli_listen.py tests/test_listener_gateway.py tests/test_listener_agent_gateway.py tests/test_listener_redaction.py`
- Result: `12 passed`
- `python3 -m pytest -q`
- Result: `246 passed`

## Risks
- Fallback response mode is intentionally synthetic; true provider pass-through can be layered later when upstream forwarding is introduced.

## Rollback
- Revert commit `41a0b74`.
