### PR TITLE
GAP-12: Update passive mode docs and UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ As of **February 23, 2026**, ReplayKit currently provides:
 - Built-in `llm capture` providers: `fake` (offline deterministic), `openai`, `anthropic`, and `google` (mock-friendly in tests, real-key capable in local runs).
 - `agent` command group with `providers` and `capture` subcommands for coding-agent session timeline capture.
 - Built-in `agent capture` adapters: `codex` and `claude-code` (fixture-runner backed for deterministic CI and local debugging).
+- Passive listener/interceptor mode via `listen start|stop|status|env` for out-of-process provider/agent capture.
 - Provider adapter contract (`docs/providers.md`) for custom model providers without modifying core capture internals.
 - Lifecycle plugin hooks via versioned plugin config (`docs/plugins.md`) for capture/replay/diff events.
 - Stable Python API entrypoint (`import replaykit`) and tool decorator capture (`@replaykit.tool`) for library integrations.
@@ -81,6 +82,19 @@ Default wrapper interception scope:
 
 - Captured automatically: `requests` and `httpx`.
 - Not captured automatically: provider SDK calls unless an adapter/hook is enabled.
+
+## Passive Listener Mode (Runnable Now)
+
+Run ReplayKit as a local listener while apps/agents run independently:
+
+```bash
+replaykit listen start --state-file runs/passive/state.json --out runs/passive/capture.rpk --json
+replaykit listen env --state-file runs/passive/state.json --shell bash
+replaykit listen status --state-file runs/passive/state.json --json
+replaykit listen stop --state-file runs/passive/state.json --json
+```
+
+Routing exports from `listen env` include provider base URLs and agent event endpoints. No API keys are emitted.
 
 ## Installation
 
@@ -130,6 +144,10 @@ GEMINI_API_KEY=... replaykit llm capture --provider google --model gemini-1.5-fl
 replaykit agent providers --json
 replaykit agent capture --agent codex --out runs/agent-codex.rpk -- python tests/fixtures/agents/fake_codex_agent.py
 replaykit agent capture --agent claude-code --out runs/agent-claude.rpk -- python tests/fixtures/agents/fake_claude_code_agent.py
+replaykit listen start --json
+replaykit listen status --json
+replaykit listen env --shell bash
+replaykit listen stop --json
 replaykit live-compare baseline.rpk --live-demo
 replaykit snapshot my-flow --candidate runs/candidate.rpk
 replaykit benchmark --source examples/runs/m2_capture_boundaries.rpk
@@ -337,6 +355,16 @@ replaykit agent capture --agent codex --out runs/agent-codex.rpk -- python tests
 replaykit agent capture --agent claude-code --out runs/agent-claude.rpk -- python tests/fixtures/agents/fake_claude_code_agent.py
 ```
 
+Passive out-of-process listener capture (provider + agent gateways):
+
+```bash
+replaykit listen start --state-file runs/passive/state.json --out runs/passive/capture.rpk --json
+replaykit listen env --state-file runs/passive/state.json --shell bash
+replaykit listen status --state-file runs/passive/state.json --json
+replaykit assert runs/passive/capture.rpk --candidate runs/passive/capture.rpk --json
+replaykit listen stop --state-file runs/passive/state.json --json
+```
+
 Launch the local UI:
 
 ```bash
@@ -395,6 +423,7 @@ Public API compatibility policy and semver guarantees:
 
 - `docs/PUBLIC_API.md`
 - `docs/plugins.md`
+- `docs/PASSIVE_LISTENER.md`
 
 Release and upgrade policy:
 

--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -1,0 +1,109 @@
+# Passive Listener Mode
+
+ReplayKit passive mode runs as a local listener/interceptor so target apps and coding agents can run independently while ReplayKit captures canonical debugging artifacts.
+
+## What It Captures
+
+- Provider gateway traffic to listener paths:
+  - OpenAI-compatible: `/v1/chat/completions`
+  - Anthropic-compatible: `/v1/messages`
+  - Gemini-compatible: `/v1beta/models/<model>:generateContent`
+- Agent event streams:
+  - Codex: `/agent/codex/events`
+  - Claude Code: `/agent/claude-code/events`
+
+Captured artifacts include canonical `model.request`, `model.response`, `tool.request`, `tool.response`, and `error.event` steps.
+
+## Commands
+
+Start listener daemon:
+
+```bash
+replaykit listen start --json
+```
+
+Stop listener daemon:
+
+```bash
+replaykit listen stop --json
+```
+
+Inspect listener status and health metrics:
+
+```bash
+replaykit listen status --json
+```
+
+Print shell exports for routing app traffic to listener:
+
+```bash
+replaykit listen env --shell bash
+replaykit listen env --shell powershell
+replaykit listen env --json
+```
+
+## Typical Workflow
+
+1. Start listener:
+
+```bash
+replaykit listen start --state-file runs/passive/state.json --out runs/passive/capture.rpk --json
+```
+
+2. Emit routing exports:
+
+```bash
+replaykit listen env --state-file runs/passive/state.json --shell bash
+```
+
+3. Run your app/agent normally (outside ReplayKit wrappers), sending provider/agent traffic to listener URLs.
+
+4. Stop listener:
+
+```bash
+replaykit listen stop --state-file runs/passive/state.json --json
+```
+
+5. Assert and replay:
+
+```bash
+replaykit assert runs/passive/capture.rpk --candidate runs/passive/capture.rpk --json
+replaykit replay runs/passive/capture.rpk --out runs/passive/replay.rpk --seed 19 --fixed-clock 2026-02-23T00:00:00Z
+```
+
+## Health and Failure Isolation
+
+`listen status --json` includes `health.metrics`:
+
+- `capture_errors`
+- `dropped_events`
+- `degraded_responses`
+
+Best-effort behavior is enabled by default:
+
+- If capture internals fail, listener returns degraded fallback provider responses and records diagnostics as `error.event`.
+- Malformed agent frames are dropped with diagnostics and metrics increments.
+
+## Security
+
+Listener persistence enforces redaction before artifact writes:
+
+- Sensitive headers are masked (`authorization`, token/key/secret-like names).
+- Sensitive payload fields (tokens, API keys, passwords, cookies) are masked.
+- Secret-like patterns in string values are redacted.
+
+Caveats:
+
+- Redaction is policy-driven and heuristic for unknown/custom formats.
+- Validate redaction coverage for proprietary payload schemas before sharing artifacts.
+
+## Troubleshooting
+
+- `listener start failed: requested port is unavailable`:
+  - Pick a different port or use `--port 0`.
+- `listen env failed: listener is not running`:
+  - Start listener first, then re-run `listen env`.
+- Repeated `dropped_events` in health metrics:
+  - Verify agent payload is JSON object/list with expected `type` fields.
+- `capture_errors` increasing:
+  - Inspect `error.event` steps in artifact and check CI/uploaded logs under `runs/passive`.


### PR DESCRIPTION
## Summary
- Add `docs/PASSIVE_LISTENER.md` with setup, command reference, routing workflow, troubleshooting, and security caveats.
- Update README with runnable passive-listener section and CLI examples.
- Document provider routing and agent endpoint usage for out-of-process capture.

## Acceptance Criteria
- [x] README contains passive mode usage and runnable commands.
- [x] `listen start|stop|status|env` behavior documented.
- [x] Provider routing (OpenAI/Anthropic/Gemini) and agent adapters (Codex/Claude Code) documented.
- [x] Security redaction guarantees and caveats documented.

## Test Evidence
- `python3 -m pytest -q`
- Result: `254 passed`

## Risks
- Documentation assumes current local gateway contract; if endpoint paths change, docs must be updated in lockstep.

## Rollback
- Revert commit `06e4682`.
