### PR TITLE
docs(gap-pm-01): define passive capture contract matrix

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -2,6 +2,9 @@
 
 ReplayKit passive mode runs as a local listener/interceptor so target apps and coding agents can run independently while ReplayKit captures canonical debugging artifacts.
 
+Passive contract details (provider matrix, streaming semantics, failure semantics):
+`docs/PASSIVE_LISTENER_ARCHITECTURE.md`
+
 ## What It Captures
 
 - Provider gateway traffic to listener paths:


### PR DESCRIPTION
## Summary
- Expand `docs/PASSIVE_LISTENER_ARCHITECTURE.md` with an explicit passive capture contract.
- Add a provider/endpoint support matrix with streaming and test references.
- Define required run/step metadata, streaming semantics, and failure semantics.
- Add a checklist mapping contract guarantees directly to existing tests and CI gate files.
- Link `docs/PASSIVE_LISTENER.md` to the contract doc.

## Acceptance Criteria
- [x] Contract doc is committed and referenced.
- [x] Provider/endpoint support matrix is explicit and testable.
- [x] Streaming semantics are unambiguous.
- [x] Failure semantics are unambiguous.
- [x] Contract checklist maps directly to test files.

## Tests (exact commands + results)
1. `python3 -m pytest -q`
   - Result: `254 passed in 25.30s`

## Risk / Rollback
- Risk: Documentation drift if implementation evolves without updating matrix/checklist.
- Rollback: Revert this docs-only commit.

Implements: `GAP-PM-01`
