### PR TITLE
feat(gap-pm-02): harden listener lifecycle command guarantees

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -42,6 +42,13 @@ replaykit listen env --shell powershell
 replaykit listen env --json
 ```
 
+Lifecycle behavior:
+
+- `listen start` auto-cleans stale state files when the recorded PID is no longer running.
+- `listen status` reports `running=false` and `stale_cleanup=true` after stale-state recovery.
+- `listen stop` is idempotent and safe to call repeatedly.
+- `listen env` output is deterministic and copy/paste-safe for both bash and PowerShell.
+
 ## Typical Workflow
 
 1. Start listener:

--- a/tests/test_cli_listen_env.py
+++ b/tests/test_cli_listen_env.py
@@ -50,6 +50,78 @@ def test_cli_listen_env_outputs_bash_exports(tmp_path: Path) -> None:
         assert stop.exit_code == 0, stop.output
 
 
+def test_cli_listen_env_bash_output_is_deterministic_and_copy_safe(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+
+    start = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert start.exit_code == 0, start.output
+
+    try:
+        first = runner.invoke(
+            app,
+            [
+                "listen",
+                "env",
+                "--state-file",
+                str(state_file),
+                "--shell",
+                "bash",
+            ],
+        )
+        second = runner.invoke(
+            app,
+            [
+                "listen",
+                "env",
+                "--state-file",
+                str(state_file),
+                "--shell",
+                "bash",
+            ],
+        )
+        assert first.exit_code == 0, first.output
+        assert second.exit_code == 0, second.output
+        assert first.stdout == second.stdout
+
+        lines = first.stdout.strip().splitlines()
+        assert len(lines) == 7
+        assert lines[0] == "# ReplayKit passive listener routing exports (no secrets)"
+        assert lines[1].startswith("export REPLAYKIT_LISTENER_URL='http://127.0.0.1:")
+        assert lines[1].endswith("'")
+        assert lines[2:] == [
+            "export OPENAI_BASE_URL=\"$REPLAYKIT_LISTENER_URL\"",
+            "export ANTHROPIC_BASE_URL=\"$REPLAYKIT_LISTENER_URL\"",
+            "export GEMINI_BASE_URL=\"$REPLAYKIT_LISTENER_URL\"",
+            "export REPLAYKIT_CODEX_EVENTS_URL=\"$REPLAYKIT_LISTENER_URL/agent/codex/events\"",
+            "export REPLAYKIT_CLAUDE_CODE_EVENTS_URL=\"$REPLAYKIT_LISTENER_URL/agent/claude-code/events\"",
+        ]
+        assert "OPENAI_API_KEY" not in first.stdout
+        assert "ANTHROPIC_API_KEY" not in first.stdout
+        assert "GEMINI_API_KEY" not in first.stdout
+    finally:
+        stop = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop.exit_code == 0, stop.output
+
+
 def test_cli_listen_env_json_and_powershell_modes(tmp_path: Path) -> None:
     runner = CliRunner()
     state_file = tmp_path / "listener-state.json"
@@ -99,6 +171,75 @@ def test_cli_listen_env_json_and_powershell_modes(tmp_path: Path) -> None:
         )
         assert ps_result.exit_code == 0, ps_result.output
         assert "$env:REPLAYKIT_LISTENER_URL" in ps_result.stdout
+    finally:
+        stop = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop.exit_code == 0, stop.output
+
+
+def test_cli_listen_env_powershell_output_is_deterministic(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+
+    start = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert start.exit_code == 0, start.output
+
+    try:
+        first = runner.invoke(
+            app,
+            [
+                "listen",
+                "env",
+                "--state-file",
+                str(state_file),
+                "--shell",
+                "powershell",
+            ],
+        )
+        second = runner.invoke(
+            app,
+            [
+                "listen",
+                "env",
+                "--state-file",
+                str(state_file),
+                "--shell",
+                "powershell",
+            ],
+        )
+        assert first.exit_code == 0, first.output
+        assert second.exit_code == 0, second.output
+        assert first.stdout == second.stdout
+
+        lines = first.stdout.strip().splitlines()
+        assert len(lines) == 7
+        assert lines[0] == "# ReplayKit passive listener routing exports (no secrets)"
+        assert lines[1].startswith("$env:REPLAYKIT_LISTENER_URL = 'http://127.0.0.1:")
+        assert lines[1].endswith("'")
+        assert lines[2:] == [
+            "$env:OPENAI_BASE_URL = $env:REPLAYKIT_LISTENER_URL",
+            "$env:ANTHROPIC_BASE_URL = $env:REPLAYKIT_LISTENER_URL",
+            "$env:GEMINI_BASE_URL = $env:REPLAYKIT_LISTENER_URL",
+            "$env:REPLAYKIT_CODEX_EVENTS_URL = $env:REPLAYKIT_LISTENER_URL + '/agent/codex/events'",
+            "$env:REPLAYKIT_CLAUDE_CODE_EVENTS_URL = $env:REPLAYKIT_LISTENER_URL + '/agent/claude-code/events'",
+        ]
     finally:
         stop = runner.invoke(
             app,


### PR DESCRIPTION
## Summary
- harden passive listener lifecycle guarantees around stale-state recovery and deterministic routing env output
- add explicit tests that `listen start` recovers stale PID state and still starts cleanly
- add deterministic output tests for `listen env --shell bash|powershell` to ensure copy/paste-safe exports and no secret vars
- document listener lifecycle guarantees in passive-mode operator docs

## Acceptance Criteria Checklist (GAP-PM-02)
- [x] repeated start/stop cycles remain stable with no orphaned listener state
- [x] status/start flows recover stale PID files and reflect real runtime state
- [x] `listen env` output is deterministic and copy/paste-safe for bash and PowerShell
- [x] lifecycle behavior is documented for operators

## Test Commands + Results
- `python3 -m pytest -q tests/test_cli_listen.py tests/test_cli_listen_env.py`
  - `10 passed in 3.42s`
- `python3 -m pytest -q`
  - `257 passed in 26.79s`
- `python3 -m pytest -q` (post-commit verification)
  - `257 passed in 27.35s`

## Risks / Rollback
- Risk: low; changes are additive tests/docs, no listener runtime logic changes.
- Rollback: revert commit `458ca51` on `feat/gap-pm-02-listener-lifecycle-commands`.
