### PR TITLE
feat(gap-pm-03): add provider upstream pass-through gateway

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -71,6 +71,23 @@ replaykit assert runs/passive/capture.rpk --candidate runs/passive/capture.rpk -
 replaykit replay runs/passive/capture.rpk --out runs/passive/replay.rpk --seed 19 --fixed-clock 2026-02-23T00:00:00Z
 ```
 
+## Optional Upstream Pass-Through
+
+By default, listener gateway returns deterministic provider-shaped synthetic responses. For live provider pass-through, set upstream base URLs before `listen start`:
+
+```bash
+export REPLAYKIT_OPENAI_UPSTREAM_URL="https://api.openai.com"
+export REPLAYKIT_ANTHROPIC_UPSTREAM_URL="https://api.anthropic.com"
+export REPLAYKIT_GEMINI_UPSTREAM_URL="https://generativelanguage.googleapis.com"
+export REPLAYKIT_LISTENER_UPSTREAM_TIMEOUT_SECONDS="5"
+```
+
+Behavior:
+
+- Successful upstream calls pass through status code and JSON body unchanged.
+- Upstream non-2xx responses are passed through with provider response shape preserved.
+- Upstream timeout/transport errors return `502` with `listener_gateway_error` payload and are captured in artifact steps.
+
 ## Health and Failure Isolation
 
 `listen status --json` includes `health.metrics`:


### PR DESCRIPTION
## Summary
- add optional provider upstream forwarding in passive listener gateway using provider-specific env vars
- preserve upstream status code and JSON payload pass-through (including non-2xx)
- keep deterministic synthetic fallback when no upstream is configured
- map upstream timeout/transport failures to `502 listener_gateway_error` and capture those failures in `model.response`
- document upstream pass-through workflow in passive listener docs

## Acceptance Criteria Checklist (GAP-PM-03)
- [x] provider-compatible ingress remains supported for OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`, and Gemini `:generateContent`
- [x] upstream forwarding + response pass-through implemented for provider routes
- [x] returned responses preserve provider-shaped JSON and status behavior
- [x] gateway non-2xx and timeout paths handled consistently and captured in artifact steps
- [x] E2E fixture tests cover provider compatibility and pass-through behavior

## Test Commands + Results
- `python3 -m pytest -q tests/test_listener_gateway.py`
  - `6 passed in 3.70s`
- `python3 -m pytest -q`
  - `257 passed in 30.75s`
- `python3 -m pytest -q` (post-commit verification)
  - `257 passed in 30.33s`

## Risks / Rollback
- Risk: medium; listener gateway now does network forwarding when upstream env vars are set.
- Mitigation: default behavior is unchanged (synthetic deterministic responses when upstream env vars are absent).
- Rollback: revert commit `fffb456` on `feat/gap-pm-03-provider-http-gateway`.
