### PR TITLE
feat(gap-pm-04): harden provider adapter canonical step mapping

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -14,6 +14,12 @@ ReplayKit passive mode runs as a local listener/interceptor so target apps and c
 
 Captured artifacts include canonical `model.request`, `model.response`, `tool.request`, `tool.response`, and `error.event` steps.
 
+Provider adapter normalization guarantees:
+
+- Every provider request/response pair is emitted as `model.request` then `model.response`.
+- Provider payload details are retained with deterministic key ordering for stable replay/diff output.
+- `correlation_id` and `request_id` metadata are propagated on both request and response steps.
+
 ## Commands
 
 Start listener daemon:

--- a/tests/fixtures/passive/provider_adapter_canonical.json
+++ b/tests/fixtures/passive/provider_adapter_canonical.json
@@ -1,0 +1,132 @@
+{
+  "anthropic": {
+    "fingerprint": "req-2db29060920fa6f4",
+    "request": {
+      "headers": {
+        "authorization": "Bearer example-auth-header",
+        "x-request-id": "anthropic-xreq-1"
+      },
+      "model": "claude-3-5-sonnet",
+      "path": "/v1/messages",
+      "payload": {
+        "messages": [
+          {
+            "content": "hello",
+            "role": "user"
+          }
+        ],
+        "model": "claude-3-5-sonnet"
+      },
+      "provider": "anthropic",
+      "request_id": "anthropic-req-001",
+      "stream": false
+    },
+    "response": {
+      "assembled_text": "hello",
+      "error": null,
+      "provider": "anthropic",
+      "response": {
+        "content": [
+          {
+            "text": "hello",
+            "type": "text"
+          }
+        ],
+        "id": "msg-upstream-001",
+        "type": "message"
+      },
+      "status_code": 200
+    }
+  },
+  "google": {
+    "fingerprint": "req-ce6320ce89eb201e",
+    "request": {
+      "headers": {
+        "x-trace": "trace-google-001"
+      },
+      "model": "gemini-1.5-flash:generateContent",
+      "path": "/v1beta/models/gemini-1.5-flash:generateContent",
+      "payload": {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "hello"
+              }
+            ],
+            "role": "user"
+          }
+        ]
+      },
+      "provider": "google",
+      "request_id": "google-req-001",
+      "stream": false
+    },
+    "response": {
+      "assembled_text": "",
+      "error": {
+        "payload": {
+          "candidates": [],
+          "error": {
+            "message": "upstream unavailable"
+          }
+        },
+        "status_code": 503
+      },
+      "provider": "google",
+      "response": {
+        "candidates": [],
+        "error": {
+          "message": "upstream unavailable"
+        }
+      },
+      "status_code": 503
+    }
+  },
+  "openai": {
+    "fingerprint": "req-1826136628f4acec",
+    "request": {
+      "headers": {
+        "authorization": "Bearer example-auth-header",
+        "x-trace": "trace-001"
+      },
+      "model": "gpt-4o-mini",
+      "path": "/v1/chat/completions",
+      "payload": {
+        "messages": [
+          {
+            "content": "hello",
+            "role": "user"
+          }
+        ],
+        "metadata": {
+          "a": 1,
+          "z": 2
+        },
+        "model": "gpt-4o-mini",
+        "stream": true
+      },
+      "provider": "openai",
+      "request_id": "openai-req-001",
+      "stream": true
+    },
+    "response": {
+      "assembled_text": "hello",
+      "error": null,
+      "provider": "openai",
+      "response": {
+        "choices": [
+          {
+            "message": {
+              "content": "hello",
+              "role": "assistant"
+            }
+          }
+        ],
+        "id": "chatcmpl-upstream-001",
+        "object": "chat.completion"
+      },
+      "status_code": 200
+    }
+  }
+}

--- a/tests/test_listener_provider_adapter.py
+++ b/tests/test_listener_provider_adapter.py
@@ -1,0 +1,126 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from replaypack.listener_gateway import (
+    normalize_provider_request,
+    normalize_provider_response,
+    provider_request_fingerprint,
+)
+
+
+def _fixture_path() -> Path:
+    return Path(__file__).parent / "fixtures" / "passive" / "provider_adapter_canonical.json"
+
+
+def test_listener_provider_adapter_canonical_snapshot() -> None:
+    openai_request = normalize_provider_request(
+        provider="openai",
+        path="/v1/chat/completions",
+        payload={
+            "stream": True,
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "gpt-4o-mini",
+            "metadata": {"z": 2, "a": 1},
+        },
+        headers={
+            "X-Trace": "trace-001",
+            "Authorization": "Bearer example-auth-header",
+            "Host": "127.0.0.1",
+        },
+        request_id="openai-req-001",
+    )
+    openai_response = normalize_provider_response(
+        provider="openai",
+        status_code=200,
+        payload={
+            "object": "chat.completion",
+            "id": "chatcmpl-upstream-001",
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+        },
+    )
+
+    anthropic_request = normalize_provider_request(
+        provider="anthropic",
+        path="/v1/messages",
+        payload={
+            "model": "claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers={
+            "x-request-id": "anthropic-xreq-1",
+            "authorization": "Bearer example-auth-header",
+        },
+        request_id="anthropic-req-001",
+    )
+    anthropic_response = normalize_provider_response(
+        provider="anthropic",
+        status_code=200,
+        payload={
+            "type": "message",
+            "id": "msg-upstream-001",
+            "content": [{"type": "text", "text": "hello"}],
+        },
+    )
+
+    google_request = normalize_provider_request(
+        provider="google",
+        path="/v1beta/models/gemini-1.5-flash:generateContent",
+        payload={
+            "contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+        },
+        headers={
+            "X-Trace": "trace-google-001",
+            "Content-Length": "999",
+            "Connection": "keep-alive",
+        },
+        request_id="google-req-001",
+    )
+    google_response = normalize_provider_response(
+        provider="google",
+        status_code=503,
+        payload={
+            "error": {"message": "upstream unavailable"},
+            "candidates": [],
+        },
+    )
+
+    actual = {
+        "openai": {
+            "request": asdict(openai_request),
+            "response": asdict(openai_response),
+            "fingerprint": provider_request_fingerprint(openai_request),
+        },
+        "anthropic": {
+            "request": asdict(anthropic_request),
+            "response": asdict(anthropic_response),
+            "fingerprint": provider_request_fingerprint(anthropic_request),
+        },
+        "google": {
+            "request": asdict(google_request),
+            "response": asdict(google_response),
+            "fingerprint": provider_request_fingerprint(google_request),
+        },
+    }
+
+    expected = json.loads(_fixture_path().read_text(encoding="utf-8"))
+    assert actual == expected
+
+
+def test_listener_provider_adapter_fingerprint_stability() -> None:
+    left = normalize_provider_request(
+        provider="openai",
+        path="/v1/chat/completions",
+        payload={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+        headers={"X-Trace": "a", "Authorization": "Bearer token"},
+        request_id="req-123",
+    )
+    right = normalize_provider_request(
+        provider="openai",
+        path="/v1/chat/completions",
+        payload={"messages": [{"content": "hello", "role": "user"}], "model": "gpt-4o-mini"},
+        headers={"Authorization": "Bearer token", "X-Trace": "a"},
+        request_id="req-123",
+    )
+
+    assert provider_request_fingerprint(left) == provider_request_fingerprint(right)


### PR DESCRIPTION
## Summary
- harden provider adapter normalization used by passive listener step capture
- normalize provider payloads/responses into deterministic stable object copies while retaining provider detail
- normalize provider headers into deterministic key ordering for stable artifact output
- add snapshot-style canonical adapter contract test fixtures for OpenAI/Anthropic/Gemini request+response mappings
- document adapter guarantees for `model.request`/`model.response` correlation metadata

## Acceptance Criteria Checklist (GAP-PM-04)
- [x] provider flow maps into canonical `model.request` and `model.response` steps
- [x] provider payload details required for replay/debug are preserved
- [x] correlation IDs remain stable and propagated
- [x] canonicalization/stability is validated by snapshot-style adapter tests
- [x] adapter unit tests cover representative OpenAI/Anthropic/Gemini payloads

## Test Commands + Results
- `python3 -m pytest -q tests/test_listener_provider_adapter.py tests/test_listener_gateway.py tests/test_listener_replay_parity.py`
  - `7 passed in 3.16s`
- `python3 -m pytest -q`
  - `256 passed in 26.38s`
- `python3 -m pytest -q` (post-commit verification)
  - `256 passed in 26.21s`

## Risks / Rollback
- Risk: low-to-medium; normalization now applies deterministic key ordering to provider request/response payload objects.
- Mitigation: payload values are preserved, only object key ordering/typed copying changed.
- Rollback: revert commit `6cd3994` on `feat/gap-pm-04-provider-adapters-step-model`.
