### PR TITLE
feat(gap-pm-07): extend redaction coverage for query and failure paths

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -124,6 +124,7 @@ Listener persistence enforces redaction before artifact writes:
 
 - Sensitive headers are masked (`authorization`, token/key/secret-like names).
 - Sensitive payload fields (tokens, API keys, passwords, cookies) are masked.
+- Sensitive query parameters are masked before request step persistence.
 - Secret-like patterns in string values are redacted.
 
 Caveats:

--- a/tests/test_listener_redaction.py
+++ b/tests/test_listener_redaction.py
@@ -1,11 +1,28 @@
 import json
 from pathlib import Path
+import re
 
 import requests
 from typer.testing import CliRunner
 
 from replaypack.artifact import read_artifact
 from replaypack.cli.app import app
+
+
+_KNOWN_SECRET_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9]{10,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"agent-super-secret-token"),
+    re.compile(r"header-token-should-not-persist"),
+)
+
+
+def _scan_for_known_secrets(text: str) -> list[str]:
+    matches: list[str] = []
+    for pattern in _KNOWN_SECRET_PATTERNS:
+        if pattern.search(text):
+            matches.append(pattern.pattern)
+    return matches
 
 
 def test_listener_persistence_redacts_provider_and_agent_secrets(tmp_path: Path) -> None:
@@ -30,12 +47,13 @@ def test_listener_persistence_redacts_provider_and_agent_secrets(tmp_path: Path)
     base_url = f"http://{started['host']}:{started['port']}"
 
     provider_secret = "sk-1234567890abcdefghij"
+    aws_secret = "AKIA1234567890ABCDEF"
     header_secret = "header-token-should-not-persist"
     agent_secret = "agent-super-secret-token"
 
     try:
         response = requests.post(
-            f"{base_url}/v1/chat/completions",
+            f"{base_url}/v1/chat/completions?api_key={provider_secret}&aws={aws_secret}",
             headers={
                 "Authorization": f"Bearer {provider_secret}",
                 "X-Custom-Token": header_secret,
@@ -43,6 +61,7 @@ def test_listener_persistence_redacts_provider_and_agent_secrets(tmp_path: Path)
             },
             json={
                 "model": "gpt-4o-mini",
+                "stream": True,
                 "messages": [{"role": "user", "content": f"use key {provider_secret}"}],
                 "api_key": provider_secret,
             },
@@ -86,6 +105,8 @@ def test_listener_persistence_redacts_provider_and_agent_secrets(tmp_path: Path)
     assert request_step.input["headers"]["x-request-id"] == "req-visible-1"
     assert request_step.input["payload"]["api_key"] == "[REDACTED]"
     assert "[REDACTED]" in request_step.input["payload"]["messages"][0]["content"]
+    assert request_step.input["query"]["api_key"] == "[REDACTED]"
+    assert request_step.input["query"]["aws"] == "[REDACTED]"
 
     tool_response_step = next(step for step in run.steps if step.type == "tool.response")
     assert tool_response_step.output["event"]["token"] == "[REDACTED]"
@@ -93,5 +114,68 @@ def test_listener_persistence_redacts_provider_and_agent_secrets(tmp_path: Path)
 
     artifact_text = out_path.read_text(encoding="utf-8")
     assert provider_secret not in artifact_text
+    assert aws_secret not in artifact_text
     assert header_secret not in artifact_text
     assert agent_secret not in artifact_text
+    assert not _scan_for_known_secrets(artifact_text)
+
+
+def test_listener_redaction_masks_failure_message_and_scanner_detects_known_leaks(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    out_path = tmp_path / "listener-redaction-failure.rpk"
+
+    start_result = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--out",
+            str(out_path),
+            "--json",
+        ],
+    )
+    assert start_result.exit_code == 0, start_result.output
+    started = json.loads(start_result.stdout.strip())
+    base_url = f"http://{started['host']}:{started['port']}"
+
+    failure_secret = "sk-aaaaaaaaaaaaaaaaaaaaaa"
+    try:
+        response = requests.post(
+            f"{base_url}/v1/chat/completions",
+            headers={"x-replaykit-fail": failure_secret},
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+            timeout=2.0,
+        )
+        assert response.status_code == 502
+    finally:
+        stop_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop_result.exit_code == 0, stop_result.output
+
+    run = read_artifact(out_path)
+    response_step = run.steps[-1]
+    assert response_step.type == "model.response"
+    assert response_step.output["error"]["message"] == "[REDACTED]"
+
+    artifact_text = out_path.read_text(encoding="utf-8")
+    assert failure_secret not in artifact_text
+    assert not _scan_for_known_secrets(artifact_text)
+
+    synthetic_leak = (
+        "Authorization: Bearer sk-1234567890abcdefghij\n"
+        "aws=AKIA1234567890ABCDEF\n"
+        "agent-super-secret-token\n"
+    )
+    findings = _scan_for_known_secrets(synthetic_leak)
+    assert len(findings) == 3


### PR DESCRIPTION
## Summary
- extend passive listener redaction to include query parameter persistence paths
- ensure failure-path error messages are redacted before artifact writes
- add regression tests covering provider headers/body/query, agent payload secrets, and failure-message redaction
- add known-pattern artifact scanner checks to prove secret leakage detection behavior
- update docs to explicitly call out query redaction

## Acceptance Criteria Checklist (GAP-PM-07)
- [x] redaction applied on request headers/body/query and response/failure payloads
- [x] no raw secrets persisted in `.rpk` artifacts under tested scenarios
- [x] token/PII style values are masked consistently across provider + agent flows
- [x] artifact scanning regression checks added for known secret patterns

## Security Proof (No Secret Persistence)
Validated via `tests/test_listener_redaction.py`:
- provider secret `sk-1234567890abcdefghij` is absent from artifact text
- AWS-like key `AKIA1234567890ABCDEF` is absent from artifact text
- header token `header-token-should-not-persist` is absent from artifact text
- agent token `agent-super-secret-token` is absent from artifact text
- failure secret `sk-aaaaaaaaaaaaaaaaaaaaaa` is absent from artifact text
- scanner check reports zero known secret pattern matches in captured artifact text

## Test Commands + Results
- `python3 -m pytest -q tests/test_listener_redaction.py`
  - `2 passed in 1.59s`
- `python3 -m pytest -q tests/test_listener_gateway.py tests/test_listener_replay_parity.py`
  - `5 passed in 3.09s`
- `python3 -m pytest -q`
  - `255 passed in 27.12s`
- `python3 -m pytest -q` (post-commit verification)
  - `255 passed in 26.52s`

## Risks / Rollback
- Risk: low; additive redaction fields/tests.
- Mitigation: existing payload shape preserved; only added redaction coverage for query + failure paths.
- Rollback: revert commit `4147878` on `feat/gap-pm-07-redaction-secret-safety`.
