### PR TITLE
feat(gap-pm-08): harden failure isolation across provider routes

### DIFF
--- a/tests/test_listener_failure_isolation.py
+++ b/tests/test_listener_failure_isolation.py
@@ -29,16 +29,42 @@ def test_listener_provider_capture_failure_serves_degraded_fallback(tmp_path: Pa
     started = json.loads(start_result.stdout.strip())
     base_url = f"http://{started['host']}:{started['port']}"
 
+    provider_cases = [
+        (
+            "/v1/chat/completions",
+            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
+            "openai",
+        ),
+        (
+            "/v1/messages",
+            {"model": "claude-3-5-sonnet", "messages": [{"role": "user", "content": "hello"}]},
+            "anthropic",
+        ),
+        (
+            "/v1beta/models/gemini-1.5-flash:generateContent",
+            {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+            "google",
+        ),
+    ]
+
     try:
-        response = requests.post(
-            f"{base_url}/v1/chat/completions",
-            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hello"}]},
-            headers={"x-replaykit-capture-fail": "1"},
-            timeout=2.0,
-        )
-        assert response.status_code == 200
-        payload = response.json()
-        assert payload["_replaykit"]["capture_status"] == "degraded"
+        for path, payload, _provider in provider_cases:
+            degraded = requests.post(
+                f"{base_url}{path}",
+                json=payload,
+                headers={"x-replaykit-capture-fail": "1"},
+                timeout=2.0,
+            )
+            assert degraded.status_code == 200
+            degraded_payload = degraded.json()
+            assert degraded_payload["_replaykit"]["capture_status"] == "degraded"
+
+            healthy = requests.post(
+                f"{base_url}{path}",
+                json=payload,
+                timeout=2.0,
+            )
+            assert healthy.status_code == 200
 
         status_result = runner.invoke(
             app,
@@ -54,8 +80,8 @@ def test_listener_provider_capture_failure_serves_degraded_fallback(tmp_path: Pa
         status_payload = json.loads(status_result.stdout.strip())
         assert status_payload["running"] is True
         metrics = status_payload["health"]["metrics"]
-        assert metrics["capture_errors"] >= 1
-        assert metrics["degraded_responses"] >= 1
+        assert metrics["capture_errors"] >= 3
+        assert metrics["degraded_responses"] >= 3
     finally:
         stop_result = runner.invoke(
             app,
@@ -75,8 +101,13 @@ def test_listener_provider_capture_failure_serves_degraded_fallback(tmp_path: Pa
         for step in run.steps
         if step.type == "error.event" and step.metadata.get("category") == "capture_failure"
     ]
-    assert error_steps
+    assert len(error_steps) >= 3
     assert "degraded fallback response" in error_steps[-1].output["message"]
+    seen_providers = {
+        str(step.output.get("details", {}).get("provider"))
+        for step in error_steps
+    }
+    assert seen_providers.issuperset({"openai", "anthropic", "google"})
 
 
 def test_listener_agent_malformed_frames_increment_dropped_metrics(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- expands failure-isolation regression coverage from a single OpenAI route to OpenAI, Anthropic, and Gemini passive-provider routes
- validates degraded fallback behavior per provider and confirms listener health for follow-up healthy requests
- asserts capture-error/degraded-response metrics increase consistently and that provider diagnostics are emitted in `error.event` steps

## Acceptance Criteria Checklist
- [x] Listener/capture failures do not crash or block routed app calls by default
- [x] `error.event` steps are emitted with actionable provider diagnostics
- [x] behavior remains aligned with best-effort failure semantics in passive listener contract

## Test Evidence
Commands run:
- `python3 -m pytest -q`

Results:
- `254 passed in 25.19s`

## Risk / Rollback
Risk:
- low; change is test-only and does not alter runtime capture behavior

Rollback:
- revert commit `500e83c` from this branch
