### PR TITLE
feat(gap-pm-09): add passive Codex/Claude JSONL ingestion diagnostics

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -14,6 +14,7 @@ Passive contract details (provider matrix, streaming semantics, failure semantic
 - Agent event streams:
   - Codex: `/agent/codex/events`
   - Claude Code: `/agent/claude-code/events`
+  - Payload formats: JSON object, JSON array, or newline-delimited JSON (JSONL)
 
 Captured artifacts include canonical `model.request`, `model.response`, `tool.request`, `tool.response`, and `error.event` steps.
 
@@ -115,7 +116,7 @@ Behavior:
 Best-effort behavior is enabled by default:
 
 - If capture internals fail, listener returns degraded fallback provider responses and records diagnostics as `error.event`.
-- Malformed agent frames are dropped with diagnostics and metrics increments.
+- Malformed agent frames are dropped with diagnostics (`parse_error` in response + `error.event`) and metrics increments.
 - Passive `.rpk` writes are atomic, so abrupt listener termination keeps the last committed artifact valid.
 
 ## Security
@@ -150,6 +151,6 @@ For provider requests with `stream=true`, passive listener artifacts store:
 - `listen env failed: listener is not running`:
   - Start listener first, then re-run `listen env`.
 - Repeated `dropped_events` in health metrics:
-  - Verify agent payload is JSON object/list with expected `type` fields.
+  - Verify agent payload is JSON object/list/JSONL with expected `type` fields.
 - `capture_errors` increasing:
   - Inspect `error.event` steps in artifact and check CI/uploaded logs under `runs/passive`.

--- a/tests/test_listener_agent_gateway.py
+++ b/tests/test_listener_agent_gateway.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+import subprocess
+import sys
 
 import requests
 from typer.testing import CliRunner
@@ -125,3 +127,103 @@ def test_listener_agent_gateway_captures_codex_and_claude_events(tmp_path: Path)
     assert "error.event" in step_types
     agents = {step.metadata.get("agent") for step in run.steps if step.metadata.get("agent")}
     assert {"codex", "claude-code"} <= agents
+
+
+def test_listener_agent_gateway_jsonl_fixture_ingestion_and_parse_diagnostics(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "listener-state.json"
+    out_path = tmp_path / "listener-agent-jsonl.rpk"
+
+    start_result = runner.invoke(
+        app,
+        [
+            "listen",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--out",
+            str(out_path),
+            "--json",
+        ],
+    )
+    assert start_result.exit_code == 0, start_result.output
+    started = json.loads(start_result.stdout.strip())
+    base_url = f"http://{started['host']}:{started['port']}"
+
+    codex_fixture = Path("tests/fixtures/agents/fake_codex_agent.py")
+    claude_fixture = Path("tests/fixtures/agents/fake_claude_code_agent.py")
+    codex_jsonl = subprocess.run(
+        [sys.executable, str(codex_fixture)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    claude_jsonl = subprocess.run(
+        [sys.executable, str(claude_fixture)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    try:
+        codex = requests.post(
+            f"{base_url}/agent/codex/events",
+            data=codex_jsonl,
+            headers={"Content-Type": "application/x-ndjson"},
+            timeout=2.0,
+        )
+        assert codex.status_code == 202
+        codex_payload = codex.json()
+        assert codex_payload["captured"] == 4
+        assert codex_payload["dropped"] == 0
+        assert codex_payload["parse_error"] is None
+
+        claude = requests.post(
+            f"{base_url}/agent/claude-code/events",
+            data=claude_jsonl,
+            headers={"Content-Type": "application/x-ndjson"},
+            timeout=2.0,
+        )
+        assert claude.status_code == 202
+        claude_payload = claude.json()
+        assert claude_payload["captured"] == 4
+        assert claude_payload["dropped"] == 0
+        assert claude_payload["parse_error"] is None
+
+        malformed = requests.post(
+            f"{base_url}/agent/codex/events",
+            data='{"type":"model.request","input":{"model":"gpt-4o-mini"}}\n{bad-json}\n',
+            headers={"Content-Type": "application/x-ndjson"},
+            timeout=2.0,
+        )
+        assert malformed.status_code == 202
+        malformed_payload = malformed.json()
+        assert malformed_payload["captured"] == 1
+        assert malformed_payload["dropped"] >= 1
+        assert malformed_payload["parse_error"] == "jsonl_partial_parse"
+    finally:
+        stop_result = runner.invoke(
+            app,
+            [
+                "listen",
+                "stop",
+                "--state-file",
+                str(state_file),
+                "--json",
+            ],
+        )
+        assert stop_result.exit_code == 0, stop_result.output
+
+    run = read_artifact(out_path)
+    listener_parse_errors = [
+        step
+        for step in run.steps
+        if step.type == "error.event" and step.metadata.get("category") == "agent_parse_failure"
+    ]
+    assert listener_parse_errors
+    latest = listener_parse_errors[-1]
+    assert latest.output["details"]["agent"] == "codex"
+    assert latest.output["details"]["reason"] == "jsonl_partial_parse"
+    assert int(latest.output["details"]["dropped_frames"]) >= 1


### PR DESCRIPTION
## Summary
- adds JSONL-aware passive agent payload parsing for `/agent/codex/events` and `/agent/claude-code/events`
- preserves best-effort ingestion by capturing valid frames even when malformed frames are mixed in
- emits explicit `error.event` diagnostics (`category=agent_parse_failure`) and includes `parse_error` in endpoint responses for observability
- extends docs and end-to-end tests with real codex/claude fixture streams

## Acceptance Criteria Checklist
- [x] both Codex and Claude Code passive stream types ingest successfully
- [x] emitted run steps remain in shared schema (`model.*`, `tool.*`, `error.event`) with passive metadata
- [x] parse errors degrade gracefully (valid frames still captured) and are observable in response + artifact diagnostics

## Test Evidence
Commands run:
- `python3 -m pytest -q tests/test_listener_agent_gateway.py tests/test_listener_failure_isolation.py`
- `python3 -m pytest -q`

Results:
- `5 passed in 2.55s`
- `255 passed in 25.94s`

## Risk / Rollback
Risk:
- low to moderate; touches listener request-body parsing for agent endpoints only

Rollback:
- revert commit `bb97f15`
