### PR TITLE
docs(gap-pm-13): publish passive-mode operator workflow runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ replaykit listen stop --state-file runs/passive/state.json --json
 
 Routing exports from `listen env` include provider base URLs and agent event endpoints. No API keys are emitted.
 
+Operator runbook with verification, streaming notes, and recovery steps:
+`docs/PASSIVE_LISTENER.md`
+
 ## Installation
 
 Install from source (current workflow):


### PR DESCRIPTION
## Summary
- expands passive listener docs into an operator-grade runbook with explicit verification checklist
- adds streaming notes/limits and recovery playbook for common failure states
- links README passive section directly to the full runbook

## Acceptance Criteria Checklist
- [x] new operator can execute passive mode end-to-end using docs only
- [x] troubleshooting/recovery section now covers practical failure handling and validation
- [x] streaming behavior and caveats are documented in one place

## Test Evidence
Commands run:
- `python3 -m pytest -q`

Results:
- `254 passed in 25.58s`

## Risk / Rollback
Risk:
- low; documentation-only change

Rollback:
- revert commit `7db98a9`
