### PR TITLE
Fix #171: add macOS transparent intercept controller

### DIFF
--- a/replaypack/transparent_macos.py
+++ b/replaypack/transparent_macos.py
@@ -1,0 +1,194 @@
+"""macOS transparent interception controller (MVP-safe scaffolding)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import subprocess
+from typing import Any, Callable
+
+CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class _PlanStep:
+    step_id: str
+    description: str
+    apply: tuple[str, ...]
+    rollback: tuple[str, ...]
+    required: bool = True
+
+
+class TransparentControllerError(RuntimeError):
+    """Raised when required transparent intercept operations fail."""
+
+    def __init__(self, message: str, *, failures: list[dict[str, Any]]) -> None:
+        super().__init__(message)
+        self.failures = failures
+
+
+def _default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _build_macos_plan(*, listener_host: str, listener_port: int) -> list[_PlanStep]:
+    listener_endpoint = f"{listener_host}:{listener_port}"
+    return [
+        _PlanStep(
+            step_id="pf.enable",
+            description=f"enable pf to allow transparent redirect to {listener_endpoint}",
+            apply=("pfctl", "-E"),
+            rollback=("pfctl", "-d"),
+            required=True,
+        ),
+        _PlanStep(
+            step_id="networksetup.preflight",
+            description="preflight network service inventory before redirect rules",
+            apply=("networksetup", "-listallnetworkservices"),
+            rollback=("networksetup", "-listallnetworkservices"),
+            required=False,
+        ),
+    ]
+
+
+def _normalize_rollback_handles(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            continue
+        command = item.get("command")
+        if not isinstance(command, list) or not all(
+            isinstance(token, str) and token for token in command
+        ):
+            continue
+        step_id = item.get("step_id")
+        normalized.append(
+            {
+                "step_id": str(step_id) if isinstance(step_id, str) and step_id else f"handle-{index}",
+                "command": list(command),
+            }
+        )
+    return normalized
+
+
+class TransparentMacOSController:
+    """Apply and revert transparent interception rules for macOS."""
+
+    def __init__(
+        self,
+        *,
+        execute: bool,
+        runner: CommandRunner | None = None,
+    ) -> None:
+        self.execute = bool(execute)
+        self.runner: CommandRunner = runner or _default_runner
+
+    def apply(
+        self,
+        *,
+        listener_host: str,
+        listener_port: int,
+    ) -> dict[str, Any]:
+        plan = _build_macos_plan(
+            listener_host=listener_host,
+            listener_port=listener_port,
+        )
+        operations: list[dict[str, Any]] = []
+        rollback_handles: list[dict[str, Any]] = []
+        failures: list[dict[str, Any]] = []
+
+        for step in plan:
+            operation: dict[str, Any] = {
+                "step_id": step.step_id,
+                "description": step.description,
+                "required": step.required,
+                "apply": list(step.apply),
+                "rollback": list(step.rollback),
+                "executed": self.execute,
+                "returncode": 0,
+                "stdout": "",
+                "stderr": "",
+            }
+            if self.execute:
+                completed = self.runner(list(step.apply))
+                operation["returncode"] = int(completed.returncode)
+                operation["stdout"] = completed.stdout or ""
+                operation["stderr"] = completed.stderr or ""
+            operations.append(operation)
+            rollback_handles.append(
+                {
+                    "step_id": step.step_id,
+                    "command": list(step.rollback),
+                }
+            )
+            if operation["returncode"] != 0 and step.required:
+                failures.append(
+                    {
+                        "step_id": step.step_id,
+                        "apply": list(step.apply),
+                        "returncode": operation["returncode"],
+                        "stderr": operation["stderr"],
+                    }
+                )
+
+        if failures:
+            raise TransparentControllerError(
+                "transparent intercept apply failed for required operation(s).",
+                failures=failures,
+            )
+
+        return {
+            "executed": self.execute,
+            "listener_host": listener_host,
+            "listener_port": listener_port,
+            "operation_count": len(operations),
+            "operations": operations,
+            "rollback_handles": rollback_handles,
+        }
+
+    def rollback(self, rollback_handles: Any) -> dict[str, Any]:
+        normalized_handles = _normalize_rollback_handles(rollback_handles)
+        attempted = 0
+        failures: list[dict[str, Any]] = []
+        operations: list[dict[str, Any]] = []
+
+        for handle in reversed(normalized_handles):
+            attempted += 1
+            command = list(handle["command"])
+            operation: dict[str, Any] = {
+                "step_id": handle["step_id"],
+                "command": command,
+                "executed": self.execute,
+                "returncode": 0,
+                "stdout": "",
+                "stderr": "",
+            }
+            if self.execute:
+                completed = self.runner(command)
+                operation["returncode"] = int(completed.returncode)
+                operation["stdout"] = completed.stdout or ""
+                operation["stderr"] = completed.stderr or ""
+            operations.append(operation)
+            if operation["returncode"] != 0:
+                failures.append(
+                    {
+                        "step_id": handle["step_id"],
+                        "command": command,
+                        "returncode": operation["returncode"],
+                        "stderr": operation["stderr"],
+                    }
+                )
+
+        return {
+            "executed": self.execute,
+            "attempted": attempted,
+            "ok": len(failures) == 0,
+            "failures": failures,
+            "operations": operations,
+        }

--- a/tests/test_cli_listen_transparent.py
+++ b/tests/test_cli_listen_transparent.py
@@ -205,3 +205,200 @@ def test_cli_listen_transparent_state_file_conflict_errors(tmp_path: Path) -> No
     assert stop_result.exit_code == 2, stop_result.output
     stop_payload = json.loads(stop_result.stdout.strip())
     assert stop_payload["status"] == "error"
+
+
+def test_cli_listen_transparent_start_records_rollback_handles(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "transparent-state.json"
+
+    monkeypatch.setattr("replaypack.cli.app._transparent_platform_name", lambda: "darwin")
+    monkeypatch.delenv("REPLAYKIT_TRANSPARENT_EXECUTE", raising=False)
+
+    start = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert start.exit_code == 0, start.output
+    started = json.loads(start.stdout.strip())
+    assert started["status"] == "ok"
+    assert started["rollback_handle_count"] >= 1
+    assert started["intercept_apply_executed"] is False
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    rollback_handles = state.get("rollback_handles")
+    assert isinstance(rollback_handles, list)
+    assert len(rollback_handles) >= 1
+
+    stop = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "stop",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert stop.exit_code == 0, stop.output
+    stopped = json.loads(stop.stdout.strip())
+    assert stopped["rollback_attempted"] == len(rollback_handles)
+
+
+def test_cli_listen_transparent_status_cleans_stale_running_state(tmp_path: Path) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "transparent-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "mode": "transparent",
+                "listener_session_id": "transparent-stale-001",
+                "pid": 999999,
+                "rollback_handles": [
+                    {"step_id": "pf.enable", "command": ["pfctl", "-d"]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "status",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout.strip())
+    assert payload["running"] is False
+    assert payload["stale_cleanup"] is True
+    assert payload["rollback_attempted"] == 1
+    assert not state_file.exists()
+
+
+def test_cli_listen_transparent_start_cleans_stale_state_and_restarts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "transparent-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "mode": "transparent",
+                "listener_session_id": "transparent-stale-start-001",
+                "pid": 999999,
+                "rollback_handles": [
+                    {"step_id": "pf.enable", "command": ["pfctl", "-d"]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("replaypack.cli.app._transparent_platform_name", lambda: "darwin")
+    monkeypatch.delenv("REPLAYKIT_TRANSPARENT_EXECUTE", raising=False)
+
+    start = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "start",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert start.exit_code == 0, start.output
+    payload = json.loads(start.stdout.strip())
+    assert payload["status"] == "ok"
+    assert payload["running"] is True
+    assert payload["stale_cleanup"] is True
+    assert payload["rollback_attempted"] == 1
+
+    stop = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "stop",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert stop.exit_code == 0, stop.output
+
+
+def test_cli_listen_transparent_stop_reports_rollback_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runner = CliRunner()
+    state_file = tmp_path / "transparent-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "mode": "transparent",
+                "listener_session_id": "transparent-stop-fail-001",
+                "pid": 0,
+                "rollback_handles": [
+                    {"step_id": "pf.enable", "command": ["pfctl", "-d"]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _rollback_failure(_self, _handles):
+        return {
+            "ok": False,
+            "attempted": 1,
+            "failures": [
+                {
+                    "step_id": "pf.enable",
+                    "command": ["pfctl", "-d"],
+                    "returncode": 1,
+                    "stderr": "permission denied",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("replaypack.cli.app.TransparentMacOSController.rollback", _rollback_failure)
+
+    result = runner.invoke(
+        app,
+        [
+            "listen",
+            "transparent",
+            "stop",
+            "--state-file",
+            str(state_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout.strip())
+    assert payload["status"] == "error"
+    assert payload["rollback_attempted"] == 1
+    assert payload["rollback_failures"]
+    assert state_file.exists()

--- a/tests/test_transparent_macos_controller.py
+++ b/tests/test_transparent_macos_controller.py
@@ -1,0 +1,67 @@
+import subprocess
+
+import pytest
+
+from replaypack.transparent_macos import (
+    TransparentControllerError,
+    TransparentMacOSController,
+)
+
+
+def test_transparent_controller_apply_dry_run_skips_runner_calls() -> None:
+    calls: list[list[str]] = []
+
+    def _runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    controller = TransparentMacOSController(execute=False, runner=_runner)
+    result = controller.apply(listener_host="127.0.0.1", listener_port=63797)
+
+    assert calls == []
+    assert result["executed"] is False
+    assert result["operation_count"] >= 1
+    assert len(result["rollback_handles"]) == result["operation_count"]
+
+
+def test_transparent_controller_apply_execute_failure_raises() -> None:
+    def _runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        if argv and argv[0] == "pfctl":
+            return subprocess.CompletedProcess(argv, 1, "", "permission denied")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    controller = TransparentMacOSController(execute=True, runner=_runner)
+
+    with pytest.raises(TransparentControllerError) as error:
+        controller.apply(listener_host="127.0.0.1", listener_port=60000)
+
+    assert error.value.failures
+    assert error.value.failures[0]["step_id"] == "pf.enable"
+
+
+def test_transparent_controller_rollback_execute_runs_reverse_order() -> None:
+    calls: list[list[str]] = []
+
+    def _runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    controller = TransparentMacOSController(execute=True, runner=_runner)
+    rollback_result = controller.rollback(
+        [
+            {"step_id": "first", "command": ["cmd", "first"]},
+            {"step_id": "second", "command": ["cmd", "second"]},
+        ]
+    )
+
+    assert rollback_result["ok"] is True
+    assert rollback_result["attempted"] == 2
+    assert calls == [["cmd", "second"], ["cmd", "first"]]
+
+
+def test_transparent_controller_rollback_ignores_invalid_handles() -> None:
+    controller = TransparentMacOSController(execute=False)
+    rollback_result = controller.rollback([{"step_id": "invalid", "command": [""]}, "bad"])
+
+    assert rollback_result["ok"] is True
+    assert rollback_result["attempted"] == 0


### PR DESCRIPTION
Closes #171.

## Summary
- add `replaypack.transparent_macos.TransparentMacOSController` with safe apply/rollback interfaces and explicit rollback handles
- wire transparent CLI lifecycle to controller apply/rollback with stale-running cleanup
- add rollback reporting fields to transparent `start|status|stop` JSON payloads
- keep CI-safe default behavior by requiring `REPLAYKIT_TRANSPARENT_EXECUTE=1` for real OS mutation command execution

## Tests
- python3 -m pytest -q
