### PR TITLE
ci: harden benchmark gate to avoid macOS timing flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,9 @@ jobs:
       - name: Benchmark Suite
         run: |
           python -c "from pathlib import Path; Path('runs').mkdir(parents=True, exist_ok=True)"
-          python -m replaypack benchmark --source examples/runs/m2_capture_boundaries.rpk --iterations 2 --out runs/ci-benchmark.json --json > runs/ci-benchmark-result.json
-          python -m replaypack benchmark --source examples/runs/m2_capture_boundaries.rpk --iterations 2 --out runs/ci-benchmark-gated.json --baseline runs/ci-benchmark.json --fail-on-slowdown 500 --json > runs/ci-benchmark-gate.json
+          # Use more samples and a wider threshold to reduce cross-run timing jitter flakiness.
+          python -m replaypack benchmark --source examples/runs/m2_capture_boundaries.rpk --iterations 5 --out runs/ci-benchmark.json --json > runs/ci-benchmark-result.json
+          python -m replaypack benchmark --source examples/runs/m2_capture_boundaries.rpk --iterations 5 --out runs/ci-benchmark-gated.json --baseline runs/ci-benchmark.json --fail-on-slowdown 1500 --json > runs/ci-benchmark-gate.json
           echo "Benchmark outputs written under runs/"
 
       - name: Cross-Platform Hash Parity


### PR DESCRIPTION
Fixes flaky CI failure seen on merge commit bb80d4e where macOS benchmark gate exceeded 500% due cross-run jitter.\n\nChanges:\n- increase benchmark iterations in CI benchmark step from 2 to 5\n- widen slowdown threshold from 500% to 1500%\n\nValidation:\n- python3 -m pytest -q\n- benchmark suite commands in workflow executed locally