### PR TITLE
Fix #204: expand route compatibility and unsupported-route diagnostics

### DIFF
--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -19,6 +19,35 @@ Passive contract details (provider matrix, streaming semantics, failure semantic
 
 Captured artifacts include canonical `model.request`, `model.response`, `tool.request`, `tool.response`, and `error.event` steps.
 
+### Route Compatibility Matrix
+
+| Method | Supported path(s) | Notes |
+| --- | --- | --- |
+| `GET` | `/health` | Listener health/metrics endpoint |
+| `GET` | `/models`, `/v1/models` | OpenAI/Codex model preflight |
+| `POST` | `/responses`, `/v1/responses` | OpenAI Responses API |
+| `POST` | `/v1/chat/completions`, `/chat/completions` | OpenAI Chat Completions |
+| `POST` | `/v1/messages`, `/messages` | Anthropic-style messages |
+| `POST` | `/v1beta/models/<model>:generateContent` | Gemini-compatible generateContent |
+| `POST` | `/agent/codex/events` | Codex agent event ingestion |
+| `POST` | `/agent/claude-code/events` | Claude Code agent event ingestion |
+
+Path compatibility notes:
+
+- Trailing slashes are accepted and normalized (for example `/responses/`).
+- Captured `metadata.path` values are normalized to canonical route paths.
+
+### Unsupported Route Contract
+
+- Unsupported path: returns `404` with:
+  - `code: "unsupported_route"`
+  - `supported_paths` for the current HTTP method
+  - remediation `hint`
+- Method mismatch on a supported path: returns `405` with:
+  - `code: "method_not_allowed"`
+  - `supported_methods`
+  - remediation `hint`
+
 Provider adapter normalization guarantees:
 
 - Every provider request/response pair is emitted as `model.request` then `model.response`.

--- a/replaypack/listener_gateway.py
+++ b/replaypack/listener_gateway.py
@@ -34,14 +34,18 @@ class ProviderResponse:
 
 
 def detect_provider(path: str) -> str | None:
-    normalized = path.strip()
+    normalized = str(path or "").strip()
+    if not normalized:
+        return None
+    if normalized != "/":
+        normalized = normalized.rstrip("/")
     if normalized in {"/models", "/v1/models"}:
         return "openai"
     if normalized in {"/responses", "/v1/responses"}:
         return "openai"
-    if normalized == "/v1/chat/completions":
+    if normalized in {"/v1/chat/completions", "/chat/completions"}:
         return "openai"
-    if normalized == "/v1/messages":
+    if normalized in {"/v1/messages", "/messages"}:
         return "anthropic"
     if normalized.startswith("/v1beta/models/") and normalized.endswith(":generateContent"):
         return "google"


### PR DESCRIPTION
Closes #204.

## What changed
- Expanded route compatibility handling with canonical path normalization (trailing slash support).
- Added support aliases for OpenAI/Anthropic route variants (`/chat/completions`, `/messages`).
- Added contract diagnostics for unsupported routes and method mismatches (`unsupported_route` and `method_not_allowed` with remediation hints).
- Documented route compatibility matrix and unsupported-route contract in passive listener docs.

## Tests run
- python3 -m pytest -q tests/test_listener_gateway.py tests/test_listener_e2e_passive_mode.py
- python3 -m pytest -q

## Manual codex passive check
- Ran codex exec --json through passive listener and verified artifact contains request/response with `/responses` path.
