### PR TITLE
Fix #205: add live-capture parity gates for passive artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,16 @@ jobs:
           python -m replaypack assert runs/golden/passive-golden-replay-a.rpk --candidate runs/golden/passive-golden-replay-b.rpk --json > runs/golden/passive-golden-assert.json
           echo "Passive golden artifact replay gate completed (runs/golden/passive-golden-*)."
 
+      - name: Passive Live-Capture Fixture Parity Gate
+        run: |
+          python -c "from pathlib import Path; Path('runs/parity').mkdir(parents=True, exist_ok=True)"
+          python -m replaypack replay examples/runs/passive_live_capture_golden.rpk --out runs/parity/passive-live-replay-a.rpk --seed 31 --fixed-clock 2026-02-26T00:00:00Z
+          python -m replaypack replay examples/runs/passive_live_capture_golden.rpk --out runs/parity/passive-live-replay-b.rpk --seed 31 --fixed-clock 2026-02-26T00:00:00Z
+          python -m replaypack assert runs/parity/passive-live-replay-a.rpk --candidate runs/parity/passive-live-replay-b.rpk --json > runs/parity/passive-live-assert.json
+          python -m replaypack diff examples/runs/passive_live_capture_golden.rpk examples/runs/passive_live_capture_candidate_diverged.rpk --json > runs/parity/passive-live-diff.json
+          python -c "import json,sys; payload=json.load(open('runs/parity/passive-live-diff.json', encoding='utf-8')); fd=payload.get('first_divergence') or {}; expected_summary={'changed':1,'identical':6,'missing_left':0,'missing_right':0}; ok=(fd.get('index')==7 and fd.get('left_step_id')=='step-live-007' and fd.get('right_step_id')=='step-live-007' and payload.get('summary')==expected_summary); print('Passive live-capture divergence signature validated.' if ok else f'Unexpected passive live-capture diff payload: {payload}'); sys.exit(0 if ok else 1)"
+          echo "Passive live-capture parity gate completed (runs/parity/passive-live-*)."
+
       - name: Passive Listener Network-Off Replay Guard
         run: |
           python ci/passive_listener_network_off_replay_guard.py

--- a/examples/runs/passive_live_capture_candidate_diverged.rpk
+++ b/examples/runs/passive_live_capture_candidate_diverged.rpk
@@ -1,0 +1,307 @@
+{
+  "checksum": "sha256:c3e18da0784f8ece0fe02441ace36594249a9544c6faf4e6fe794cf06d74b043",
+  "metadata": {
+    "created_at": "2026-02-26T00:00:00.000000Z",
+    "run_id": "run-passive-live-candidate-001"
+  },
+  "payload": {
+    "run": {
+      "capture_mode": "passive",
+      "environment_fingerprint": {
+        "os": "darwin",
+        "python": "3.12.2",
+        "session": "sanitized-live"
+      },
+      "id": "run-passive-live-candidate-001",
+      "listener_bind": {
+        "host": "127.0.0.1",
+        "port": 61234
+      },
+      "listener_process": {
+        "pid": 4242
+      },
+      "listener_session_id": "listener-live-golden-001",
+      "provider": "openai",
+      "runtime_versions": {
+        "python": "3.12.2",
+        "replaypack": "0.1.0"
+      },
+      "source": "listener",
+      "steps": [
+        {
+          "hash": "sha256:e23790953fa53fed6487439c4e2f51b53548023e2404f98868d99aa94666bb07",
+          "id": "step-live-001",
+          "input": {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "summarize the repo",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user",
+                "type": "message"
+              },
+              {
+                "call_id": "call-live-0001",
+                "name": "shell",
+                "output": {
+                  "stdout": "README.md\nAGENTS.md\n"
+                },
+                "type": "function_call_output"
+              }
+            ],
+            "model": "gpt-5.3-codex",
+            "stream": true
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001",
+            "response_source": "upstream"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:01.000000Z",
+          "type": "model.request"
+        },
+        {
+          "hash": "sha256:9009fe44d108f0204c949d123c4553c8dcec8db7c5614ec9bceed462d9dafd03",
+          "id": "step-live-002",
+          "input": {
+            "call_id": "call-live-0001",
+            "tool": "shell",
+            "type": "function_call_output"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "derived_from": "openai.responses.request_input",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001"
+          },
+          "output": {
+            "result": {
+              "stdout": "README.md\nAGENTS.md\n"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:02.000000Z",
+          "type": "tool.response"
+        },
+        {
+          "hash": "sha256:abf5211840ab6ba8e3241ecbc069dd58a54139ef02507f4db2db841d2df6e331",
+          "id": "step-live-003",
+          "input": {
+            "request_id": "openai-request-live-0001"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001",
+            "response_source": "upstream"
+          },
+          "output": {
+            "assembled_text": "I am reading the README to summarize key points.",
+            "output": {
+              "id": "resp-live-0001",
+              "model": "gpt-5.3-codex",
+              "object": "response",
+              "output": [
+                {
+                  "arguments": {
+                    "command": "cat README.md | head -n 3"
+                  },
+                  "call_id": "call-live-0002",
+                  "name": "shell",
+                  "type": "function_call"
+                },
+                {
+                  "content": [
+                    {
+                      "text": "I am reading the README to summarize key points.",
+                      "type": "output_text"
+                    }
+                  ],
+                  "role": "assistant",
+                  "type": "message"
+                }
+              ],
+              "output_text": "I am reading the README to summarize key points.",
+              "status": "completed"
+            },
+            "stream": {
+              "completion_state": "completed",
+              "event_count": 3,
+              "event_types": [
+                "response.output_text.delta",
+                "response.output_text.delta",
+                "response.completed"
+              ],
+              "events": [
+                {
+                  "delta": "I am reading the README ",
+                  "type": "response.output_text.delta"
+                },
+                {
+                  "delta": "to summarize key points.",
+                  "type": "response.output_text.delta"
+                },
+                {
+                  "terminal": true,
+                  "type": "response.completed"
+                }
+              ],
+              "outcome": "completed",
+              "terminal_event_type": "response.completed"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:03.000000Z",
+          "type": "model.response"
+        },
+        {
+          "hash": "sha256:954987a045a2ff5f15c1559deface6db539d733ad70f39fb29796a69a6aa7399",
+          "id": "step-live-004",
+          "input": {
+            "arguments": {
+              "command": "cat README.md | head -n 3"
+            },
+            "call_id": "call-live-0002",
+            "tool": "shell"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "derived_from": "openai.responses.response_output",
+            "event_type": "function_call",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:04.000000Z",
+          "type": "tool.request"
+        },
+        {
+          "hash": "sha256:6f59dda2a7ca1e856aa8248de3b86cc39ccae9578233dc567bdfc9c8c7304f53",
+          "id": "step-live-005",
+          "input": {
+            "input": [
+              {
+                "call_id": "call-live-0002",
+                "name": "shell",
+                "output": {
+                  "stdout": "# ReplayKit\n\nReplay debugging toolkit."
+                },
+                "type": "function_call_output"
+              }
+            ],
+            "model": "gpt-5.3-codex",
+            "stream": false
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002",
+            "response_source": "upstream"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:05.000000Z",
+          "type": "model.request"
+        },
+        {
+          "hash": "sha256:d43b6e1560e177ce8129962195ada78410485cf1c78cf42d25d98bc8916ae816",
+          "id": "step-live-006",
+          "input": {
+            "call_id": "call-live-0002",
+            "tool": "shell",
+            "type": "function_call_output"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "derived_from": "openai.responses.request_input",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002"
+          },
+          "output": {
+            "result": {
+              "stdout": "# ReplayKit\n\nReplay debugging toolkit."
+            }
+          },
+          "timestamp": "2026-02-26T00:00:06.000000Z",
+          "type": "tool.response"
+        },
+        {
+          "hash": "sha256:fb0644bc02cc0fc85e93bc49d6e846ab6fe00ae65a97635e805250ad983ef00c",
+          "id": "step-live-007",
+          "input": {
+            "request_id": "openai-request-live-0002"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002",
+            "response_source": "upstream"
+          },
+          "output": {
+            "assembled_text": "ReplayKit is a deterministic replay toolkit focused on first-divergence debugging.",
+            "output": {
+              "id": "resp-live-0002",
+              "model": "gpt-5.3-codex",
+              "object": "response",
+              "output": [
+                {
+                  "content": [
+                    {
+                      "text": "ReplayKit is a deterministic replay toolkit focused on first-divergence debugging.",
+                      "type": "output_text"
+                    }
+                  ],
+                  "role": "assistant",
+                  "type": "message"
+                }
+              ],
+              "output_text": "ReplayKit is a deterministic replay toolkit focused on first-divergence debugging.",
+              "status": "completed"
+            },
+            "stream": {
+              "completion_state": "completed",
+              "event_count": 1,
+              "event_types": [
+                "response.completed"
+              ],
+              "events": [
+                {
+                  "terminal": true,
+                  "type": "response.completed"
+                }
+              ],
+              "outcome": "not_streaming",
+              "terminal_event_type": "response.completed"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:07.000000Z",
+          "type": "model.response"
+        }
+      ],
+      "timestamp": "2026-02-26T00:00:00.000000Z"
+    }
+  },
+  "version": "1.0"
+}

--- a/examples/runs/passive_live_capture_golden.rpk
+++ b/examples/runs/passive_live_capture_golden.rpk
@@ -1,0 +1,307 @@
+{
+  "checksum": "sha256:5ae9c0d4e8a01f1eae10c6a182a6d65983cff6919ec33f8bdb4f6e647da2198d",
+  "metadata": {
+    "created_at": "2026-02-26T00:00:00.000000Z",
+    "run_id": "run-passive-live-golden-001"
+  },
+  "payload": {
+    "run": {
+      "capture_mode": "passive",
+      "environment_fingerprint": {
+        "os": "darwin",
+        "python": "3.12.2",
+        "session": "sanitized-live"
+      },
+      "id": "run-passive-live-golden-001",
+      "listener_bind": {
+        "host": "127.0.0.1",
+        "port": 61234
+      },
+      "listener_process": {
+        "pid": 4242
+      },
+      "listener_session_id": "listener-live-golden-001",
+      "provider": "openai",
+      "runtime_versions": {
+        "python": "3.12.2",
+        "replaypack": "0.1.0"
+      },
+      "source": "listener",
+      "steps": [
+        {
+          "hash": "sha256:e23790953fa53fed6487439c4e2f51b53548023e2404f98868d99aa94666bb07",
+          "id": "step-live-001",
+          "input": {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "summarize the repo",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user",
+                "type": "message"
+              },
+              {
+                "call_id": "call-live-0001",
+                "name": "shell",
+                "output": {
+                  "stdout": "README.md\nAGENTS.md\n"
+                },
+                "type": "function_call_output"
+              }
+            ],
+            "model": "gpt-5.3-codex",
+            "stream": true
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001",
+            "response_source": "upstream"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:01.000000Z",
+          "type": "model.request"
+        },
+        {
+          "hash": "sha256:9009fe44d108f0204c949d123c4553c8dcec8db7c5614ec9bceed462d9dafd03",
+          "id": "step-live-002",
+          "input": {
+            "call_id": "call-live-0001",
+            "tool": "shell",
+            "type": "function_call_output"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "derived_from": "openai.responses.request_input",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001"
+          },
+          "output": {
+            "result": {
+              "stdout": "README.md\nAGENTS.md\n"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:02.000000Z",
+          "type": "tool.response"
+        },
+        {
+          "hash": "sha256:abf5211840ab6ba8e3241ecbc069dd58a54139ef02507f4db2db841d2df6e331",
+          "id": "step-live-003",
+          "input": {
+            "request_id": "openai-request-live-0001"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001",
+            "response_source": "upstream"
+          },
+          "output": {
+            "assembled_text": "I am reading the README to summarize key points.",
+            "output": {
+              "id": "resp-live-0001",
+              "model": "gpt-5.3-codex",
+              "object": "response",
+              "output": [
+                {
+                  "arguments": {
+                    "command": "cat README.md | head -n 3"
+                  },
+                  "call_id": "call-live-0002",
+                  "name": "shell",
+                  "type": "function_call"
+                },
+                {
+                  "content": [
+                    {
+                      "text": "I am reading the README to summarize key points.",
+                      "type": "output_text"
+                    }
+                  ],
+                  "role": "assistant",
+                  "type": "message"
+                }
+              ],
+              "output_text": "I am reading the README to summarize key points.",
+              "status": "completed"
+            },
+            "stream": {
+              "completion_state": "completed",
+              "event_count": 3,
+              "event_types": [
+                "response.output_text.delta",
+                "response.output_text.delta",
+                "response.completed"
+              ],
+              "events": [
+                {
+                  "delta": "I am reading the README ",
+                  "type": "response.output_text.delta"
+                },
+                {
+                  "delta": "to summarize key points.",
+                  "type": "response.output_text.delta"
+                },
+                {
+                  "terminal": true,
+                  "type": "response.completed"
+                }
+              ],
+              "outcome": "completed",
+              "terminal_event_type": "response.completed"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:03.000000Z",
+          "type": "model.response"
+        },
+        {
+          "hash": "sha256:954987a045a2ff5f15c1559deface6db539d733ad70f39fb29796a69a6aa7399",
+          "id": "step-live-004",
+          "input": {
+            "arguments": {
+              "command": "cat README.md | head -n 3"
+            },
+            "call_id": "call-live-0002",
+            "tool": "shell"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0001",
+            "derived_from": "openai.responses.response_output",
+            "event_type": "function_call",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0001"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:04.000000Z",
+          "type": "tool.request"
+        },
+        {
+          "hash": "sha256:6f59dda2a7ca1e856aa8248de3b86cc39ccae9578233dc567bdfc9c8c7304f53",
+          "id": "step-live-005",
+          "input": {
+            "input": [
+              {
+                "call_id": "call-live-0002",
+                "name": "shell",
+                "output": {
+                  "stdout": "# ReplayKit\n\nReplay debugging toolkit."
+                },
+                "type": "function_call_output"
+              }
+            ],
+            "model": "gpt-5.3-codex",
+            "stream": false
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002",
+            "response_source": "upstream"
+          },
+          "output": {
+            "status": "captured"
+          },
+          "timestamp": "2026-02-26T00:00:05.000000Z",
+          "type": "model.request"
+        },
+        {
+          "hash": "sha256:d43b6e1560e177ce8129962195ada78410485cf1c78cf42d25d98bc8916ae816",
+          "id": "step-live-006",
+          "input": {
+            "call_id": "call-live-0002",
+            "tool": "shell",
+            "type": "function_call_output"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "derived_from": "openai.responses.request_input",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002"
+          },
+          "output": {
+            "result": {
+              "stdout": "# ReplayKit\n\nReplay debugging toolkit."
+            }
+          },
+          "timestamp": "2026-02-26T00:00:06.000000Z",
+          "type": "tool.response"
+        },
+        {
+          "hash": "sha256:a9bfdf7802fb6bb50a722c09536320d6a61cb157fb07dd130759dea38f3932c5",
+          "id": "step-live-007",
+          "input": {
+            "request_id": "openai-request-live-0002"
+          },
+          "metadata": {
+            "capture_mode": "passive",
+            "correlation_id": "req-live-0002",
+            "path": "/responses",
+            "provider": "openai",
+            "request_id": "openai-request-live-0002",
+            "response_source": "upstream"
+          },
+          "output": {
+            "assembled_text": "ReplayKit is a local-first debugging toolkit for deterministic replay and diffing.",
+            "output": {
+              "id": "resp-live-0002",
+              "model": "gpt-5.3-codex",
+              "object": "response",
+              "output": [
+                {
+                  "content": [
+                    {
+                      "text": "ReplayKit is a local-first debugging toolkit for deterministic replay and diffing.",
+                      "type": "output_text"
+                    }
+                  ],
+                  "role": "assistant",
+                  "type": "message"
+                }
+              ],
+              "output_text": "ReplayKit is a local-first debugging toolkit for deterministic replay and diffing.",
+              "status": "completed"
+            },
+            "stream": {
+              "completion_state": "completed",
+              "event_count": 1,
+              "event_types": [
+                "response.completed"
+              ],
+              "events": [
+                {
+                  "terminal": true,
+                  "type": "response.completed"
+                }
+              ],
+              "outcome": "not_streaming",
+              "terminal_event_type": "response.completed"
+            }
+          },
+          "timestamp": "2026-02-26T00:00:07.000000Z",
+          "type": "model.response"
+        }
+      ],
+      "timestamp": "2026-02-26T00:00:00.000000Z"
+    }
+  },
+  "version": "1.0"
+}

--- a/tests/test_listener_live_capture_parity.py
+++ b/tests/test_listener_live_capture_parity.py
@@ -1,0 +1,147 @@
+import json
+import socket
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from replaypack.artifact import read_artifact
+from replaypack.cli.app import app
+
+
+BASELINE_FIXTURE = Path("examples/runs/passive_live_capture_golden.rpk")
+CANDIDATE_FIXTURE = Path("examples/runs/passive_live_capture_candidate_diverged.rpk")
+
+
+def test_live_capture_golden_fixture_is_sanitized_and_step_complete() -> None:
+    assert BASELINE_FIXTURE.exists()
+    assert CANDIDATE_FIXTURE.exists()
+
+    run = read_artifact(BASELINE_FIXTURE)
+    assert run.capture_mode == "passive"
+    assert [step.type for step in run.steps] == [
+        "model.request",
+        "tool.response",
+        "model.response",
+        "tool.request",
+        "model.request",
+        "tool.response",
+        "model.response",
+    ]
+
+    paths = [step.metadata.get("path") for step in run.steps if step.type.startswith("model.")]
+    assert paths == ["/responses", "/responses", "/responses", "/responses"]
+    assert all(step.metadata.get("response_source") == "upstream" for step in run.steps if step.type == "model.response")
+
+    raw = BASELINE_FIXTURE.read_text(encoding="utf-8")
+    assert "Authorization" not in raw
+    assert "Bearer " not in raw
+    assert "sk-" not in raw
+
+
+def test_live_capture_fixture_stub_replay_is_deterministic_offline(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runner = CliRunner()
+    replay_a = tmp_path / "live-capture-replay-a.rpk"
+    replay_b = tmp_path / "live-capture-replay-b.rpk"
+
+    def _blocked_create_connection(*_args, **_kwargs):
+        raise OSError("network disabled for live-capture replay parity test")
+
+    monkeypatch.setattr(socket, "create_connection", _blocked_create_connection)
+
+    replay_one = runner.invoke(
+        app,
+        [
+            "replay",
+            str(BASELINE_FIXTURE),
+            "--out",
+            str(replay_a),
+            "--seed",
+            "31",
+            "--fixed-clock",
+            "2026-02-26T00:00:00Z",
+        ],
+    )
+    assert replay_one.exit_code == 0, replay_one.output
+
+    replay_two = runner.invoke(
+        app,
+        [
+            "replay",
+            str(BASELINE_FIXTURE),
+            "--out",
+            str(replay_b),
+            "--seed",
+            "31",
+            "--fixed-clock",
+            "2026-02-26T00:00:00Z",
+        ],
+    )
+    assert replay_two.exit_code == 0, replay_two.output
+    assert replay_a.read_bytes() == replay_b.read_bytes()
+
+    assertion = runner.invoke(
+        app,
+        [
+            "assert",
+            str(replay_a),
+            "--candidate",
+            str(replay_b),
+            "--json",
+        ],
+    )
+    assert assertion.exit_code == 0, assertion.output
+    payload = json.loads(assertion.stdout.strip())
+    assert payload["status"] == "pass"
+    assert payload["first_divergence"] is None
+    assert payload["summary"] == {
+        "changed": 0,
+        "identical": 7,
+        "missing_left": 0,
+        "missing_right": 0,
+    }
+
+
+def test_live_capture_fixture_first_divergence_is_stable() -> None:
+    runner = CliRunner()
+
+    first = runner.invoke(
+        app,
+        [
+            "diff",
+            str(BASELINE_FIXTURE),
+            str(CANDIDATE_FIXTURE),
+            "--json",
+        ],
+    )
+    second = runner.invoke(
+        app,
+        [
+            "diff",
+            str(BASELINE_FIXTURE),
+            str(CANDIDATE_FIXTURE),
+            "--json",
+        ],
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+
+    first_payload = json.loads(first.stdout.strip())
+    second_payload = json.loads(second.stdout.strip())
+    assert first_payload["first_divergence"] == second_payload["first_divergence"]
+
+    divergence = first_payload["first_divergence"]
+    assert divergence["index"] == 7
+    assert divergence["left_step_id"] == "step-live-007"
+    assert divergence["right_step_id"] == "step-live-007"
+    assert divergence["left_type"] == "model.response"
+    assert divergence["right_type"] == "model.response"
+    assert first_payload["summary"] == {
+        "changed": 1,
+        "identical": 6,
+        "missing_left": 0,
+        "missing_right": 0,
+    }


### PR DESCRIPTION
Closes #205.

## Summary
- add sanitized live-capture passive fixtures under examples/runs
- add deterministic replay + first-divergence stability tests for those fixtures
- add CI parity gate that validates replay determinism and divergence signature for live-capture fixtures

## Tests
- python3 -m pytest -q tests/test_listener_live_capture_parity.py tests/test_listener_replay_parity.py
- python3 -m pytest -q
- codex exec --json passive listener smoke with artifact validation
