### PR TITLE
Fix #206: add passive operational controls for health, rotation, and retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ As of **February 23, 2026**, ReplayKit currently provides:
 - Built-in `agent capture` adapters: `codex` and `claude-code` (fixture-runner backed for deterministic CI and local debugging).
 - Passive listener/interceptor mode via `listen start|stop|status|env` for out-of-process provider/agent capture.
 - Passive listener OpenAI Responses normalization that derives `tool.request/tool.response` steps when tool-call payloads are present.
+- Passive listener operational controls via `listen cleanup` and configurable artifact rotation/retention (`--rotation-max-steps`, `--retention-max-artifacts`).
 - macOS transparent listener lifecycle via `listen transparent doctor|start|status|stop` with rollback journaling and stale-session cleanup.
 - Provider adapter contract (`docs/providers.md`) for custom model providers without modifying core capture internals.
 - Lifecycle plugin hooks via versioned plugin config (`docs/plugins.md`) for capture/replay/diff events.
@@ -94,6 +95,9 @@ replaykit listen start --state-file runs/passive/state.json --out runs/passive/c
 replaykit listen env --state-file runs/passive/state.json --shell bash
 replaykit listen status --state-file runs/passive/state.json --json
 replaykit listen stop --state-file runs/passive/state.json --json
+# optional long-running controls
+replaykit listen start --state-file runs/passive/state.json --out runs/passive/capture.rpk --rotation-max-steps 5000 --retention-max-artifacts 20 --json
+replaykit listen cleanup --artifact-dir runs/passive --glob "*.rpk" --keep 20 --json
 ```
 
 Routing exports from `listen env` include provider base URLs and agent event endpoints. No API keys are emitted.

--- a/docs/PASSIVE_LISTENER.md
+++ b/docs/PASSIVE_LISTENER.md
@@ -61,6 +61,8 @@ Start listener daemon:
 
 ```bash
 replaykit listen start --json
+# optional long-running controls:
+replaykit listen start --json --rotation-max-steps 5000 --retention-max-artifacts 20
 ```
 
 Stop listener daemon:
@@ -81,6 +83,12 @@ Print shell exports for routing app traffic to listener:
 replaykit listen env --shell bash
 replaykit listen env --shell powershell
 replaykit listen env --json
+```
+
+Prune old artifacts manually (count-based retention):
+
+```bash
+replaykit listen cleanup --artifact-dir runs/listener --glob "*.rpk" --keep 20 --json
 ```
 
 Lifecycle behavior:
@@ -225,12 +233,20 @@ If any checklist item fails, use the recovery playbook below before re-running.
 - `capture_errors`
 - `dropped_events`
 - `degraded_responses`
+- `rotation_max_steps`
+- `retention_max_artifacts`
+- `rotated_artifacts`
+- `retained_rotation_artifacts`
+- `retention_pruned_artifacts`
+- `rotation_last_at`
 
 Best-effort behavior is enabled by default:
 
 - If capture internals fail, listener returns degraded fallback provider responses and records diagnostics as `error.event`.
 - Malformed agent frames are dropped with diagnostics (`parse_error` in response + `error.event`) and metrics increments.
 - Passive `.rpk` writes are atomic, so abrupt listener termination keeps the last committed artifact valid.
+- When `--rotation-max-steps` is configured, listener snapshots rotated segments as
+  `<artifact>.part-<index>.rpk` and enforces `--retention-max-artifacts` automatically.
 
 ## Security
 


### PR DESCRIPTION
Closes #206.

## Summary
- add listener operational controls for artifact rotation and retention
- expose rotation/retention runtime settings in listen start/status JSON and health metrics
- add `listen cleanup` command for manual artifact retention pruning
- document operational controls in README + passive listener runbook

## Tests
- python3 -m pytest -q tests/test_cli_listen.py tests/test_listener_cleanup_regression.py tests/test_listener_failure_isolation.py
- python3 -m pytest -q
- codex exec --json passive listener validation with rotation/retention enabled (artifact + rotated part verification)
